### PR TITLE
Firefox fixes for tokenization demo

### DIFF
--- a/packages/demo/tokenization/package-lock.json
+++ b/packages/demo/tokenization/package-lock.json
@@ -2820,11 +2820,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -12403,7 +12398,7 @@
       "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
       "requires": {
         "bluebird": "3.5.1",
-        "buffer": "5.2.0",
+        "buffer": "5.2.1",
         "decompress": "4.2.0",
         "eth-lib": "0.1.27",
         "fs-extra": "2.1.2",
@@ -12418,9 +12413,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
-          "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+          "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
           "requires": {
             "base64-js": "1.3.0",
             "ieee754": "1.1.12"
@@ -12616,7 +12611,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
@@ -13144,7 +13139,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "requires": {
             "base64-js": "0.0.8",
@@ -13508,23 +13503,23 @@
       }
     },
     "web3": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.35.tgz",
-      "integrity": "sha512-xwDmUhvTcHQvvNnOPcPZZgCxKUsI2e+GbHy7JkTK3/Rmnutazy8x7fsAXT9myw7V1qpi3GgLoZ3fkglSUbg1Mg==",
+      "version": "1.0.0-beta.34",
+      "resolved": "http://registry.npmjs.org/web3/-/web3-1.0.0-beta.34.tgz",
+      "integrity": "sha1-NH5WG3hAmMtVYzFfSQR5odkfKrE=",
       "requires": {
-        "web3-bzz": "1.0.0-beta.35",
-        "web3-core": "1.0.0-beta.35",
-        "web3-eth": "1.0.0-beta.35",
-        "web3-eth-personal": "1.0.0-beta.35",
-        "web3-net": "1.0.0-beta.35",
-        "web3-shh": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-bzz": "1.0.0-beta.34",
+        "web3-core": "1.0.0-beta.34",
+        "web3-eth": "1.0.0-beta.34",
+        "web3-eth-personal": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34",
+        "web3-shh": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-bzz": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.35.tgz",
-      "integrity": "sha512-BhAU0qhlr8zltm4gs/+P1gki2VkxHJaM2Rrh4DGesDW0lzwufRoNvWFlwx1bKHoFPWNbSmm9PRkHOYOINL/Tgw==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.34.tgz",
+      "integrity": "sha1-Bo03d3q2Xlxg+OyLmlDP5FJ3kpw=",
       "requires": {
         "got": "7.1.0",
         "swarm-js": "0.1.37",
@@ -13555,42 +13550,42 @@
       }
     },
     "web3-core": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.35.tgz",
-      "integrity": "sha512-ayGavbgVk4KL9Y88Uv411fBJ0SVgVfKhKEBweKYzmP0zOqneMzWt6YsyD1n6kRvjAbqA0AfUPEOKyMNjcx2tjw==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.34.tgz",
+      "integrity": "sha1-EhvoVV6fsA0sXQXd0zgdDJ5GmH4=",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-core-requestmanager": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-requestmanager": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-core-helpers": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.35.tgz",
-      "integrity": "sha512-APOu3sEsamyqWt//8o4yq9KF25/uqGm+pQShson/sC4gKzmfJB07fLo2ond0X30E8fIqAPeVCotPXQxGciGUmA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.34.tgz",
+      "integrity": "sha1-sWjaANPhnhVrwVriAyA91N/uLQM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-eth-iban": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-core-method": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.35.tgz",
-      "integrity": "sha512-jidImCide8q0GpfsO4L73qoHrbkeWgwU3uOH5DKtJtv0ccmG086knNMRgryb/o9ZgetDWLmDEsJnHjBSoIwcbA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.34.tgz",
+      "integrity": "sha1-7BY8iixJD6AqfsFVWfpzB/x8xt0=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-promievent": "1.0.0-beta.35",
-        "web3-core-subscriptions": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-promievent": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-core-promievent": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.35.tgz",
-      "integrity": "sha512-GvqXqKq07OmHuVi5uNRg6k79a1/CI0ViCC+EtNv4CORHtDRmYEt5Bvdv6z6FJEiaaQkD0lKbFwNhLxutx7HItw==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.34.tgz",
+      "integrity": "sha1-pPT6Z4S7KT6CxglgrltWqUzQPtw=",
       "requires": {
         "any-promise": "1.3.0",
         "eventemitter3": "1.1.1"
@@ -13604,25 +13599,25 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.35.tgz",
-      "integrity": "sha512-S+zW2h17ZZQU9oe3yaCJE0E7aJS4C3Kf4kGPDv+nXjW0gKhQQhgVhw1Doq/aYQGqNSWJp7f1VHkz5gQWwg6RRg==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.34.tgz",
+      "integrity": "sha1-Afj2zyrmtvC3DDi64e90G1urIVw=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-providers-http": "1.0.0-beta.35",
-        "web3-providers-ipc": "1.0.0-beta.35",
-        "web3-providers-ws": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-providers-http": "1.0.0-beta.34",
+        "web3-providers-ipc": "1.0.0-beta.34",
+        "web3-providers-ws": "1.0.0-beta.34"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.35.tgz",
-      "integrity": "sha512-gXzLrWvcGkGiWq1y33Z4Y80XI8XMrwowiQJkrPSjQ81K5PBKquOGwcMffLaKcwdmEy/NpsOXDeFo3eLE1Ghvvw==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.34.tgz",
+      "integrity": "sha1-n+0UQDPyIcPPIQYDAv/a9e8t4t4=",
       "requires": {
         "eventemitter3": "1.1.1",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34"
       },
       "dependencies": {
         "eventemitter3": {
@@ -13633,33 +13628,33 @@
       }
     },
     "web3-eth": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.35.tgz",
-      "integrity": "sha512-04mcb2nGPXThawuuYICPOxv0xOHofvQKsjZeIq+89nyOC8DQMGTAErDkGyMHQYtjpth5XDhic0wuEsA80AmFZA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.34.tgz",
+      "integrity": "sha1-dAhgAIUMb+b1Ne9Jg31tS7YRMmg=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-core-subscriptions": "1.0.0-beta.35",
-        "web3-eth-abi": "1.0.0-beta.35",
-        "web3-eth-accounts": "1.0.0-beta.35",
-        "web3-eth-contract": "1.0.0-beta.35",
-        "web3-eth-iban": "1.0.0-beta.35",
-        "web3-eth-personal": "1.0.0-beta.35",
-        "web3-net": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-eth-abi": "1.0.0-beta.34",
+        "web3-eth-accounts": "1.0.0-beta.34",
+        "web3-eth-contract": "1.0.0-beta.34",
+        "web3-eth-iban": "1.0.0-beta.34",
+        "web3-eth-personal": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-eth-abi": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.35.tgz",
-      "integrity": "sha512-KUDC+EtFFYG8z01ZleKrASdjj327/rtWHzEt6RWsEj7bBa0bGp9nEh+nqdZx/Sdgz1O8tnfFzJlrRcXpfr1vGg==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.34.tgz",
+      "integrity": "sha1-A0Uz46ovfln/MXk+rqaFwO1a9no=",
       "requires": {
         "bn.js": "4.11.6",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       },
       "dependencies": {
         "bn.js": {
@@ -13670,9 +13665,9 @@
       }
     },
     "web3-eth-accounts": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.35.tgz",
-      "integrity": "sha512-duIgRsfht/0kAW/eQ0X9lKtVIykbETrnM2H7EnvplCzPHtQLodpib4o9JXfh9n6ZDgdDC7cuJoiVB9QJg089ew==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.34.tgz",
+      "integrity": "sha1-4JFC7uzHl6w0WbdemyOUbTaV8zM=",
       "requires": {
         "any-promise": "1.3.0",
         "crypto-browserify": "3.12.0",
@@ -13680,10 +13675,10 @@
         "scrypt.js": "0.2.0",
         "underscore": "1.8.3",
         "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       },
       "dependencies": {
         "eth-lib": {
@@ -13704,27 +13699,27 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.35.tgz",
-      "integrity": "sha512-foPohOg5O1UCGKGZOIs+kQK5IZdV2QQ7pAWwNxH8WHplUA+fre1MurXNpoxknUmH6mYplFhXjqgYq2MsrBpHrA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.34.tgz",
+      "integrity": "sha1-nbs4+udkOoCEJ6IBgEcOx0FckeY=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-core-promievent": "1.0.0-beta.35",
-        "web3-core-subscriptions": "1.0.0-beta.35",
-        "web3-eth-abi": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-promievent": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-eth-abi": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-eth-iban": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.35.tgz",
-      "integrity": "sha512-H5wkcNcAIc+h/WoDIKv7ZYmrM2Xqu3O7jBQl1IWo73EDVQji+AoB2i3J8tuwI1yZRInRwrfpI3Zuwuf54hXHmQ==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.34.tgz",
+      "integrity": "sha1-mvRYYFhnzPdOqXmq8yazi6alugw=",
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-utils": "1.0.0-beta.34"
       },
       "dependencies": {
         "bn.js": {
@@ -13735,25 +13730,25 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.35.tgz",
-      "integrity": "sha512-AcM9nnlxu7ZRRxPvkrFB9eLxMM4A2cPfj2aCg21Wb2EpMnhR+b/O1cT33k7ApRowoMpM+T9M8vx2oPNwXfaCOQ==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.34.tgz",
+      "integrity": "sha1-mvuhZzQuveVCC81YlcP2w0OI8gU=",
       "requires": {
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-helpers": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-net": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-helpers": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-net": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.35.tgz",
-      "integrity": "sha512-bbwaQ/KohGjIJ6HAKbZ6KrklCAaG6/B7hIbAbVLSFLxF+Yz9lmAgQYaDInpidpC/NLb3WOmcbRF+P77J4qMVIA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.34.tgz",
+      "integrity": "sha1-QnzqL0MYgUScjjjVIykPFz+f9j0=",
       "requires": {
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-utils": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-utils": "1.0.0-beta.34"
       }
     },
     "web3-provider-engine": {
@@ -13818,49 +13813,49 @@
       }
     },
     "web3-providers-http": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.35.tgz",
-      "integrity": "sha512-DcIMFq52Fb08UpWyZ3ZlES6NsNqJnco4hBS/Ej6eOcASfuUayPI+GLkYVZsnF3cBYqlH+DOKuArcKSuIxK7jIA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.34.tgz",
+      "integrity": "sha1-5WG1K7tDdmKCAH1AKFv+NVDCfno=",
       "requires": {
-        "web3-core-helpers": "1.0.0-beta.35",
-        "xhr2-cookies": "1.1.0"
+        "web3-core-helpers": "1.0.0-beta.34",
+        "xhr2": "0.1.4"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.35.tgz",
-      "integrity": "sha512-iB0FG0HcpUnayfa8pn4guqEQ4Y1nrroi/jffdtQgFkrNt0sD3fMSwwC0AbmECqj3tDLl0e1slBR0RENll+ZF0g==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.34.tgz",
+      "integrity": "sha1-obd/GjBtc2SanAOQUuQMtxMo0Ao=",
       "requires": {
         "oboe": "2.1.3",
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35"
+        "web3-core-helpers": "1.0.0-beta.34"
       }
     },
     "web3-providers-ws": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.35.tgz",
-      "integrity": "sha512-Cx64NgDStynKaUGDIIOfaCd0fZusL8h5avKTkdTjUu2aHhFJhZoVBGVLhoDtUaqZGWIZGcBJOoVf2JkGUOjDRQ==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.34.tgz",
+      "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.35",
+        "web3-core-helpers": "1.0.0-beta.34",
         "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-shh": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.35.tgz",
-      "integrity": "sha512-8qSonk/x0xabERS9Sr6AIADN/Ty+5KwARkkGIfSYHKqFpdMDz+76F7cUCxtoCZoS8K04xgZlDKYe0TJXLYA0Fw==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.34.tgz",
+      "integrity": "sha1-l1Bh1x6uxCzO5Xb3vY9w8DhEr+A=",
       "requires": {
-        "web3-core": "1.0.0-beta.35",
-        "web3-core-method": "1.0.0-beta.35",
-        "web3-core-subscriptions": "1.0.0-beta.35",
-        "web3-net": "1.0.0-beta.35"
+        "web3-core": "1.0.0-beta.34",
+        "web3-core-method": "1.0.0-beta.34",
+        "web3-core-subscriptions": "1.0.0-beta.34",
+        "web3-net": "1.0.0-beta.34"
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.35.tgz",
-      "integrity": "sha512-Dq6f0SOKj3BDFRgOPnE6ALbzBDCKVIW8mKWVf7tGVhTDHf+wQaWwQSC3aArFSqdExB75BPBPyDpuMTNszhljpA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.34.tgz",
+      "integrity": "sha1-lBH8OarvOcpOBhafdiKX2f8CCXA=",
       "requires": {
         "bn.js": "4.11.6",
         "eth-lib": "0.1.27",
@@ -14484,16 +14479,7 @@
     "xhr2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
-      "dev": true
-    },
-    "xhr2-cookies": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-      "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-      "requires": {
-        "cookiejar": "2.1.2"
-      }
+      "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8="
     },
     "xml-name-validator": {
       "version": "2.0.1",

--- a/packages/demo/tokenization/package.json
+++ b/packages/demo/tokenization/package.json
@@ -24,7 +24,7 @@
     "redux": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-saga": "^0.16.0",
-    "web3": "^1.0.0-beta.35"
+    "web3": "^1.0.0-beta.34"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/demo/tokenization/src/pages/Wallet/index.js
+++ b/packages/demo/tokenization/src/pages/Wallet/index.js
@@ -67,7 +67,8 @@ const styles = theme => ({
   paperPara: {
     fontWeight: 300,
     marginBottom: '2em',
-    wordBreak: 'break-word',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
   },
   paperFooter: {
     display: 'flex',

--- a/packages/demo/tokenization/src/pages/_common/Confirmation.js
+++ b/packages/demo/tokenization/src/pages/_common/Confirmation.js
@@ -21,7 +21,8 @@ const styles = ({
     color: userConfirmationValue,
     fontWeight: 'bold',
     marginBottom: '0.5em',
-    wordBreak: 'break-word',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
   },
 });
 


### PR DESCRIPTION
- Set web3 version to `1.0.0-beta.34` to avoid CORS issues when connecting to infura
- Firefox doesn't support `word-break: break-word`, use alternative:
   ```css
   white-space: pre-wrap;
   word-break: break-all;
   ```