### PR TITLE
Fix toTokenAmount method returning amount in exponential form

### DIFF
--- a/packages/demo/tokenization/src/utils/token.js
+++ b/packages/demo/tokenization/src/utils/token.js
@@ -5,7 +5,7 @@ export const toTokenAmount = amount => (
   (new Decimal(amount))
     .times((new Decimal(10)).toPower(18))
     .todp(0, Decimal.ROUND_DOWN)
-    .toString()
+    .toFixed()
 );
 
 export const fromTokenAmount = (amount, dp) => (


### PR DESCRIPTION
The `toString` method of our decimal library will use exponential notation if there are more than 20 zeros, see [here](http://mikemcl.github.io/decimal.js-light/#toExpPos). Switching to `toFixed` will always give the result in normal notation.

Fixes #37 