### PR TITLE
Stellar payments listening for identity bridge service

### DIFF
--- a/packages/demo/bridge/Gopkg.lock
+++ b/packages/demo/bridge/Gopkg.lock
@@ -53,6 +53,33 @@
   version = "v1.8.17"
 
 [[projects]]
+  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
+  name = "github.com/fatih/color"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
+
+[[projects]]
+  digest = "1:aacef5f5e45685f2aeda5534d0a750dee6859de7e9088cdd06192787bb01ae6d"
+  name = "github.com/go-errors/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a6af135bd4e28680facf08a3d206b454abc877a4"
+  version = "v1.0.1"
+
+[[projects]]
+  digest = "1:083bd57e1a2b764eb19b70e7816bc1385b30d73191540e2756dceb445eff2eb2"
+  name = "github.com/gocraft/dbr"
+  packages = [
+    ".",
+    "dialect",
+  ]
+  pruneopts = "UT"
+  revision = "b542ddb88301820e373c3152d83dd6cab8786985"
+  version = "v2.3"
+
+[[projects]]
   digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
   name = "github.com/lib/pq"
   packages = [
@@ -62,6 +89,30 @@
   pruneopts = "UT"
   revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:31bd492aa2822484bcec518e0b693e1aedfdf9637b43527c0ad29d5cf8abfd43"
+  name = "github.com/manucorporat/sse"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "ee05b128a739a0fb76c7ebd3ae4810c1de808d6d"
+
+[[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
 
 [[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
@@ -80,16 +131,45 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:54bd573538ca13ccf85d18c99249d934f17957f17263256b42565a11c854c1de"
+  name = "github.com/segmentio/go-loggly"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3e0cec4266ddf583aecef51bb8e9badc3cca5314"
+  version = "v0.5.0"
+
+[[projects]]
+  digest = "1:622a93cd4d5e98d0fc84d61f8a70968cecbbd781dc62f1917ac59f9f36308378"
+  name = "github.com/sirupsen/logrus"
+  packages = [
+    ".",
+    "hooks/test",
+  ]
+  pruneopts = "UT"
+  revision = "68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a"
+
+[[projects]]
   branch = "master"
-  digest = "1:c3388b2a90a1396c2a98fae93412eb9f10cb44853032acfd37d572eb57218230"
+  digest = "1:0f09e87d780174a94174eb83c481f41c93a6baa8f53e4459241fbd99e62f2827"
   name = "github.com/stellar/go"
   packages = [
+    "amount",
+    "build",
+    "clients/horizon",
     "crc16",
     "hash",
     "keypair",
     "network",
+    "price",
+    "protocols/horizon",
+    "protocols/horizon/base",
     "strkey",
     "support/errors",
+    "support/http/mutil",
+    "support/log",
+    "support/render/hal",
+    "support/render/problem",
+    "support/url",
     "xdr",
   ]
   pruneopts = "UT"
@@ -125,6 +205,37 @@
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
+  version = "v1.3.2"
+
+[[projects]]
+  digest = "1:60bf2a5e347af463c42ed31a493d817f8a72f102543060ed992754e689805d1a"
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:c52caf7bd44f92e54627a31b85baf06a68333a196b3d8d241480a774733dcf8b"
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = "UT"
+  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
+  version = "v1.9.1"
+
+[[projects]]
   branch = "master"
   digest = "1:69b3fcb7a41b18436a85471cbdcfc70ad10ba3206f8c87563e1c773610e1bcad"
   name = "golang.org/x/crypto"
@@ -147,20 +258,35 @@
   pruneopts = "UT"
   revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
+[[projects]]
+  digest = "1:a4b04b5314d49a67ad022fa7693453ee2b823ab99314f52fa3930ed31085dfef"
+  name = "gopkg.in/guregu/null.v3"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "80515d440932108546bcade467bb7d6968e812e2"
+  version = "v3.4.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
     "github.com/ethereum/go-ethereum/crypto",
+    "github.com/fatih/color",
+    "github.com/gocraft/dbr",
+    "github.com/stellar/go/clients/horizon",
     "github.com/stellar/go/keypair",
     "github.com/stellar/go/strkey",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
     "github.com/stretchr/testify/suite",
+    "go.uber.org/zap",
+    "go.uber.org/zap/buffer",
+    "go.uber.org/zap/zapcore",
     "golang.org/x/crypto/scrypt",
     "golang.org/x/crypto/ssh/terminal",
+    "gopkg.in/guregu/null.v3",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/packages/demo/bridge/services/identity/db/internal.go
+++ b/packages/demo/bridge/services/identity/db/internal.go
@@ -1,0 +1,87 @@
+package db
+
+import (
+	"database/sql/driver"
+	"time"
+
+	"github.com/gocraft/dbr/dialect"
+)
+
+// Tables
+const (
+	tableStellarAccounts  = "stellar_accounts"
+	tableReceivedPayments = "stellar_received_payments"
+	tableLinkRequests     = "link_requests"
+)
+
+// Columns
+const (
+	columnID           = "id"
+	columnLastCreated  = "last_created"
+	columnLastModified = "last_modified"
+	columnStatus       = "status"
+	columnRemarks      = "remarks"
+
+	columnAddress = "address"
+	columnCursor  = "cursor"
+
+	columnToAccountID = "to_account_id"
+	columnFromAccount = "from_account"
+	columnPaymentID   = "payment_id"
+	columnTxHash      = "tx_hash"
+	columnPagingToken = "paging_token"
+	columnMemoType    = "memo_type"
+	columnMemo        = "memo"
+
+	columnReceivedPaymentID = "received_payment_id"
+	columnEthereumAddress   = "ethereum_address"
+)
+
+// pgTimeFormat is RFC3339 which has timezone information and accepted by pg
+var pgTimeFormat = time.RFC3339
+
+// pgTimezone implements dbr.Dialect and adds in the extra timestamp formatting
+// step.
+type pgTimezone struct{}
+
+// QuoteIdent serves the same functionality as dialect.PostgreSQL.QuoteIdent.
+func (d pgTimezone) QuoteIdent(s string) string {
+	return dialect.PostgreSQL.QuoteIdent(s)
+}
+
+// EncodeString serves the same functionality as dialect.PostgreSQL.EncodeString.
+func (d pgTimezone) EncodeString(s string) string {
+	return dialect.PostgreSQL.EncodeString(s)
+}
+
+// EncodeBool serves the same functionality as dialect.PostgreSQL.EncodeBool.
+func (d pgTimezone) EncodeBool(b bool) string {
+	return dialect.PostgreSQL.EncodeBool(b)
+}
+
+// EncodeTime encodes the timestamp using the PgTimeFormat.
+func (d pgTimezone) EncodeTime(t time.Time) string {
+	return `'` + t.UTC().Format(pgTimeFormat) + `'`
+}
+
+// EncodeBytes serves the same functionality as dialect.PostgreSQL.EncodeBytes.
+func (d pgTimezone) EncodeBytes(b []byte) string {
+	return dialect.PostgreSQL.EncodeBytes(b)
+}
+
+// Placeholder serves the same functionality as dialect.PostgreSQL.Placeholder.
+func (d pgTimezone) Placeholder(n int) string {
+	return dialect.PostgreSQL.Placeholder(n)
+}
+
+// sql now utility function with timezone
+type pgBetterNowSentinel struct{}
+
+// pgNowTZ replaces dbr.Now
+// NOTE: DO NOT USE dbr.Now unless db is timezone is in UTC
+var pgNowTZ = pgBetterNowSentinel{}
+
+func (n pgBetterNowSentinel) Value() (driver.Value, error) {
+	now := time.Now().UTC().Format(pgTimeFormat)
+	return now, nil
+}

--- a/packages/demo/bridge/services/identity/db/main.go
+++ b/packages/demo/bridge/services/identity/db/main.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"github.com/gocraft/dbr"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/support/stellar"
+	"go.uber.org/zap"
+	"gopkg.in/guregu/null.v3"
+)
+
+const (
+	ReceivedPaymentStatusMissingMemo = iota
+	ReceivedPaymentStatusInvalidMemoType
+	ReceivedPaymentStatusInvalidMemoFormat
+	ReceivedPaymentStatusPendingLinkRequest
+)
+
+const (
+	LinkRequestStatusPendingValidation = iota
+	LinkRequestStatusValidationFailed
+	LinkRequestStatusQueued
+	LinkRequestStatusSuccess
+	LinkRequestStatusError
+)
+
+type Database interface {
+	// Loads a stellar account from the database given an stellar address. A new
+	// account will be inserted if no account exists.
+	LoadStellarAccount(address string) (*StellarAccount, error)
+
+	CreateReceivedPayment(payment ReceivedPayment) (int64, error)
+	CreateLinkRequest(request LinkRequest) (int64, error)
+
+	SetStellarAccountCursor(id int64, cursor string) (int64, error)
+}
+
+type PostgresDB struct {
+	*dbr.Connection
+	Logger *zap.Logger
+}
+
+type Timestamp struct {
+	LastCreated  string `db:"last_created"`
+	LastModified string `db:"last_modified"`
+}
+
+type StellarAccount struct {
+	ID      int64       `db:"id"`
+	Address string      `db:"address"`
+	Cursor  null.String `db:"cursor"`
+	Status  int64       `db:"status"`
+	Timestamp
+}
+
+type ReceivedPayment struct {
+	ID          int64            `db:"id"`
+	ToAccountID int64            `db:"to_account_id"`
+	FromAccount string           `db:"from_account"`
+	PaymentID   int64            `db:"payment_id"`
+	TxHash      string           `db:"tx_hash"`
+	PagingToken string           `db:"paging_token"`
+	Status      int64            `db:"status"`
+	MemoType    stellar.MemoType `db:"memo_type"`
+	Memo        null.String      `db:"memo"`
+	Timestamp
+}
+
+type LinkRequest struct {
+	ID                int64       `db:"id"`
+	ReceivedPaymentID int64       `db:"received_payment_id"`
+	EthereumAddress   string      `db:"ethereum_address"`
+	TxHash            null.String `db:"tx_hash"`
+	Status            int64       `db:"status"`
+	Remarks           null.String `db:"remarks"`
+	Timestamp
+}
+
+func NewPostgresDB(pgURL string, logger *zap.Logger) (Database, error) {
+	eventReceiver := DbrTracer{Logger: logger}
+
+	conn, err := dbr.Open("postgres", pgURL, &eventReceiver)
+	if err != nil {
+		return nil, err
+	}
+	conn.Dialect = pgTimezone{}
+
+	return &PostgresDB{
+		Connection: conn,
+		Logger:     logger,
+	}, nil
+}

--- a/packages/demo/bridge/services/identity/db/migrations/20181001152909_create_accounts_table.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181001152909_create_accounts_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE accounts;

--- a/packages/demo/bridge/services/identity/db/migrations/20181001152909_create_accounts_table.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181001152909_create_accounts_table.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE stellar_accounts (
+  id                serial                        PRIMARY KEY NOT NULL,
+  address           varchar(64)                   NOT NULL,
+  cursor            varchar(64)                   ,
+  status            int                           NOT NULL default 0,
+  last_created      timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+  last_modified     timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+
+  CONSTRAINT uniq_address UNIQUE(address)
+);
+
+CREATE OR REPLACE FUNCTION update_last_modified_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.last_modified = now();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER stellar_accounts_modtime BEFORE UPDATE ON stellar_accounts FOR EACH ROW EXECUTE PROCEDURE update_last_modified_column();

--- a/packages/demo/bridge/services/identity/db/migrations/20181010155306_create_received_payments_table.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181010155306_create_received_payments_table.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE stellar_received_payments;
+UPDATE accounts SET cursor = NULL;

--- a/packages/demo/bridge/services/identity/db/migrations/20181010155306_create_received_payments_table.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181010155306_create_received_payments_table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE stellar_received_payments (
+  id                serial                        PRIMARY KEY NOT NULL,
+  to_account_id     int                           NOT NULL REFERENCES stellar_accounts(id),
+  from_account      varchar(64)                   NOT NULL,
+  payment_id        bigint                        NOT NULL default 0,
+  tx_hash           varchar(64)                   NOT NULL,
+  paging_token      varchar(64)                   NOT NULL UNIQUE,
+  status            int                           NOT NULL default 0,
+  memo_type         int                           NOT NULL default 0,
+  memo              varchar(64)                   ,
+  last_created      timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+  last_modified     timestamp with time zone      NOT NULL DEFAULT current_timestamp
+);
+CREATE UNIQUE INDEX stellar_received_payments_uniq_id ON stellar_received_payments (payment_id) WHERE payment_id != 0;
+CREATE TRIGGER stellar_received_payments_modtime BEFORE UPDATE ON stellar_received_payments FOR EACH ROW EXECUTE PROCEDURE update_last_modified_column();

--- a/packages/demo/bridge/services/identity/db/migrations/20181011172228_create_link_requests_table.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181011172228_create_link_requests_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE link_requests;

--- a/packages/demo/bridge/services/identity/db/migrations/20181011172228_create_link_requests_table.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181011172228_create_link_requests_table.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE link_requests (
+  id                    serial                        PRIMARY KEY NOT NULL,
+  received_payment_id   int                           NOT NULL REFERENCES stellar_received_payments(id),
+  ethereum_address      varchar(64)                   NOT NULL,
+  tx_hash               varchar(64)                   ,
+  status                int                           NOT NULL default 0,
+  remarks               text                          ,
+  last_created          timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+  last_modified         timestamp with time zone      NOT NULL DEFAULT current_timestamp
+);
+
+CREATE UNIQUE INDEX link_requests_uniq_hash ON link_requests (tx_hash) WHERE tx_hash IS NOT NULL;
+CREATE TRIGGER link_requests_modtime BEFORE UPDATE ON link_requests FOR EACH ROW EXECUTE PROCEDURE update_last_modified_column();

--- a/packages/demo/bridge/services/identity/db/postgres.go
+++ b/packages/demo/bridge/services/identity/db/postgres.go
@@ -1,0 +1,184 @@
+package db
+
+import (
+	"github.com/gocraft/dbr"
+	"go.uber.org/zap"
+)
+
+func (d *PostgresDB) LoadStellarAccount(address string) (*StellarAccount, error) {
+	sess := d.Connection.NewSession(nil)
+
+	res := &StellarAccount{}
+
+	err := sess.
+		Select("*").
+		From(tableStellarAccounts).
+		Where(dbr.And(
+			dbr.Eq(columnAddress, address),
+		)).
+		LoadOne(res)
+
+	if err == nil {
+		return res, nil
+	}
+
+	if err != nil && err != dbr.ErrNotFound {
+		return nil, err
+	}
+
+	tx, err := sess.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var id int64
+	err = tx.
+		InsertInto(tableStellarAccounts).
+		Columns(columnAddress).
+		Values(address).
+		Returning(columnID).
+		Load(&id)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.
+		Select("*").
+		From(tableStellarAccounts).
+		Where(dbr.And(
+			dbr.Eq(columnID, id),
+		)).
+		LoadOne(res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, tx.Commit()
+}
+
+func (d *PostgresDB) CreateReceivedPayment(payment ReceivedPayment) (int64, error) {
+	sess := d.Connection.NewSession(nil)
+	tx, err := sess.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.RollbackUnlessCommitted()
+
+	var accountCursor dbr.NullString
+	var currentPaymentID int64
+
+	err = tx.
+		Select(columnCursor).
+		From(tableStellarAccounts).
+		Where(dbr.And(
+			dbr.Eq(columnID, payment.ToAccountID),
+		)).
+		LoadOne(&accountCursor)
+	if err != nil {
+		d.Logger.Error("Failed to get current cursor",
+			zap.Error(err),
+			zap.Int64(columnID, payment.ToAccountID),
+		)
+		return 0, err
+	}
+
+	if accountCursor.Valid {
+		err = tx.
+			Select(columnPagingToken).
+			From(tableReceivedPayments).
+			Where(dbr.And(
+				dbr.Eq(columnToAccountID, payment.ToAccountID),
+				dbr.Eq(columnPagingToken, accountCursor.String),
+			)).
+			LoadOne(&currentPaymentID)
+		if err != nil && err != dbr.ErrNotFound {
+			d.Logger.Error("Failed to get payment id",
+				zap.Error(err),
+				zap.Int64(columnToAccountID, payment.ToAccountID),
+				zap.String(columnPagingToken, accountCursor.String),
+			)
+			return 0, err
+		}
+	}
+
+	var id int64
+	err = tx.
+		InsertInto(tableReceivedPayments).
+		Columns(
+			columnToAccountID,
+			columnFromAccount,
+			columnPaymentID,
+			columnTxHash,
+			columnPagingToken,
+			columnStatus,
+			columnMemoType,
+			columnMemo,
+		).
+		Record(payment).
+		Returning(columnID).
+		Load(&id)
+	if err != nil {
+		d.Logger.Error("Failed to insert received payment",
+			zap.Error(err),
+			zap.Any("payment", payment),
+		)
+		return 0, err
+	}
+
+	if !accountCursor.Valid || currentPaymentID < payment.PaymentID {
+		_, err = tx.
+			Update(tableStellarAccounts).
+			Set(columnCursor, payment.PagingToken).
+			Where(dbr.And(
+				dbr.Eq(columnID, payment.ToAccountID),
+			)).
+			Exec()
+		if err != nil {
+			d.Logger.Error("Failed to update account cursor",
+				zap.Error(err),
+				zap.String(columnCursor, payment.PagingToken),
+			)
+			return 0, err
+		}
+	}
+
+	return id, tx.Commit()
+}
+
+func (d *PostgresDB) CreateLinkRequest(request LinkRequest) (int64, error) {
+	sess := d.Connection.NewSession(nil)
+
+	var id int64
+	err := sess.
+		InsertInto(tableLinkRequests).
+		Columns(
+			columnReceivedPaymentID,
+			columnEthereumAddress,
+			columnTxHash,
+			columnStatus,
+			columnRemarks,
+		).
+		Record(request).
+		Returning(columnID).
+		Load(&id)
+	if err != nil {
+		return 0, err
+	}
+
+	return id, nil
+}
+
+func (d *PostgresDB) SetStellarAccountCursor(id int64, cursor string) (int64, error) {
+	sess := d.Connection.NewSession(nil)
+
+	results, err := sess.
+		Update(tableStellarAccounts).
+		Set(columnCursor, cursor).
+		Exec()
+	if err != nil {
+		return 0, err
+	}
+
+	return results.RowsAffected()
+}

--- a/packages/demo/bridge/services/identity/db/tracer.go
+++ b/packages/demo/bridge/services/identity/db/tracer.go
@@ -1,0 +1,105 @@
+package db
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+/*
+dbr events triggers found after digging through dbr source code
+- dbr.go/exec
+	- EventErrKv("dbr.exec.interpolate", err, kvs{
+			"sql":  query,
+			"args": fmt.Sprint(value),
+		})
+	- EventErrKv("dbr.exec.exec", err, kvs{
+			"sql": query,
+		})
+	- TimingKv("dbr.exec", time.Since(startTime).Nanoseconds(), kvs{
+			"sql": query,
+		})
+- dbr.go/query
+	- EventErrKv("dbr.select.interpolate", err, kvs{
+			"sql":  query,
+			"args": fmt.Sprint(value),
+		})
+	- EventErrKv("dbr.select.load.query", err, kvs{
+			"sql": query,
+		})
+	- EventErrKv("dbr.select.load.scan", err, kvs{
+			"sql": query,
+		})
+	- TimingKv("dbr.select", time.Since(startTime).Nanoseconds(), kvs{
+			"sql": query,
+		})
+- transaction.go/BeginTx
+	- EventErr("dbr.begin.error", err)
+	- Event("dbr.begin")
+- transaction.go/Commit
+	- EventErr("dbr.commit.error", err)
+	- Event("dbr.commit")
+- transaction.go/Rollback
+	- EventErr("dbr.rollback", err)
+	- Event("dbr.rollback")
+- transaction.go/RollbackUnlessCommitted
+	- EventErr("dbr.rollback_unless_committed", err)
+	- Event("dbr.rollback")
+*/
+
+// DbrTracer implements dbr.EventReceiver to trace dbr events.
+type DbrTracer struct {
+	Logger *zap.Logger
+}
+
+// Event receives a simple notification when various events occur
+func (d *DbrTracer) Event(eventName string) {
+}
+
+// EventKv receives a notification when various events occur along with
+// optional key/value data
+func (d *DbrTracer) EventKv(eventName string, kvs map[string]string) {
+	// Currently not in use by dbr
+}
+
+// EventErr receives a notification of an error if one occurs
+func (d *DbrTracer) EventErr(eventName string, err error) error {
+	return err
+}
+
+// EventErrKv receives a notification of an error if one occurs along with
+// optional key/value data
+func (d *DbrTracer) EventErrKv(eventName string, err error, kvs map[string]string) error {
+	values := []zap.Field{
+		zap.String("event", eventName),
+		zap.Error(err),
+	}
+	for k, v := range kvs {
+		values = append(values, zap.String(k, v))
+	}
+	d.Logger.Debug("dbr error", values...)
+	return err
+}
+
+// Timing receives the time an event took to happen
+func (d *DbrTracer) Timing(eventName string, nanoseconds int64) {
+	// Currently not in use by dbr
+}
+
+// TimingKv receives the time an event took to happen along with optional
+// key/value data
+func (d *DbrTracer) TimingKv(eventName string, nanoseconds int64, kvs map[string]string) {
+	if query, ok := kvs["sql"]; ok {
+		d.Logger.Debug("dbr query",
+			zap.String("event", eventName),
+			zap.String("query", query),
+			zap.Float64("time taken", float64(nanoseconds)/float64(time.Second)),
+		)
+	}
+}
+
+func (d *DbrTracer) setTags(kvs map[string]string) {
+	if query, ok := kvs["sql"]; ok {
+		d.Logger.Debug("dbr query", zap.String("query", query))
+	}
+}

--- a/packages/demo/bridge/services/identity/eventhandler/main.go
+++ b/packages/demo/bridge/services/identity/eventhandler/main.go
@@ -1,0 +1,15 @@
+package eventhandler
+
+import (
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"github.com/stellar/go/clients/horizon"
+	"go.uber.org/zap"
+)
+
+type StellarPaymentHandler struct {
+	Logger        *zap.Logger
+	Fatalities    chan error
+	DB            db.Database
+	HorizonClient *horizon.Client
+	LinkRequests  chan db.LinkRequest
+}

--- a/packages/demo/bridge/services/identity/eventhandler/stellar_payment_handler.go
+++ b/packages/demo/bridge/services/identity/eventhandler/stellar_payment_handler.go
@@ -1,0 +1,137 @@
+package eventhandler
+
+import (
+	"strconv"
+
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/support/stellar"
+	"github.com/stellar/go/clients/horizon"
+	"go.uber.org/zap"
+	"gopkg.in/guregu/null.v3"
+)
+
+func (h *StellarPaymentHandler) Receive(account *db.StellarAccount, payment *horizon.Payment) {
+	switch payment.Type {
+	case "create_account":
+		h.handleAccountCreation(account, payment)
+	case "payment":
+		h.handleIncomingPayment(account, payment)
+	}
+}
+
+func (h *StellarPaymentHandler) handleAccountCreation(account *db.StellarAccount, payment *horizon.Payment) {
+	if account.Cursor.Valid {
+		return
+	}
+
+	rowsAffected, err := h.DB.SetStellarAccountCursor(account.ID, payment.PagingToken)
+	if err != nil || rowsAffected == 0 {
+		h.Logger.Error("Unable to set account cursor",
+			zap.Error(err),
+			zap.Int64("Account ID", account.ID),
+			zap.String("Account address", account.Address),
+			zap.String("Cursor", payment.PagingToken),
+		)
+	}
+}
+
+func (h *StellarPaymentHandler) handleIncomingPayment(account *db.StellarAccount, payment *horizon.Payment) {
+	ethAddress, memo, memoType := h.parseMemo(payment)
+
+	receivedPayment := db.ReceivedPayment{
+		ToAccountID: account.ID,
+		FromAccount: payment.From,
+		TxHash:      payment.TransactionHash,
+		PagingToken: payment.PagingToken,
+		MemoType:    memoType,
+		Memo:        memo,
+	}
+	if id, err := strconv.Atoi(payment.ID); err == nil {
+		receivedPayment.PaymentID = int64(id)
+	}
+
+	switch payment.Type {
+	case "create_account":
+		receivedPayment.FromAccount = payment.Funder
+	}
+
+	if !memo.Valid {
+		receivedPayment.Status = db.ReceivedPaymentStatusMissingMemo
+	} else if memoType != stellar.MemoTypeHash {
+		receivedPayment.Status = db.ReceivedPaymentStatusInvalidMemoType
+	} else if ethAddress == nil {
+		receivedPayment.Status = db.ReceivedPaymentStatusInvalidMemoFormat
+	} else {
+		receivedPayment.Status = db.ReceivedPaymentStatusPendingLinkRequest
+	}
+
+	var err error
+
+	receivedPayment.ID, err = h.DB.CreateReceivedPayment(receivedPayment)
+	if err != nil {
+		h.Logger.Error("Unable to create received payment",
+			zap.Error(err),
+			zap.Any("Payment", payment),
+			zap.Any("Received payment", receivedPayment),
+		)
+		return
+	}
+
+	if ethAddress == nil {
+		return
+	}
+
+	linkRequest := db.LinkRequest{
+		ReceivedPaymentID: receivedPayment.ID,
+		EthereumAddress:   *ethAddress,
+		Status:            db.LinkRequestStatusPendingValidation,
+	}
+	linkRequest.ID, err = h.DB.CreateLinkRequest(linkRequest)
+	if err != nil {
+		h.Logger.Error("Unable to create link request",
+			zap.Error(err),
+			zap.Any("Link Request", linkRequest),
+			zap.Any("Received payment", receivedPayment),
+		)
+		return
+	}
+
+	h.Logger.Debug("Enqueue link request",
+		zap.Any("Link Request", linkRequest),
+		zap.Any("Received payment", receivedPayment),
+	)
+	h.LinkRequests <- linkRequest
+}
+
+func (h *StellarPaymentHandler) parseMemo(payment *horizon.Payment) (ethAddress *string, memo null.String, memoType stellar.MemoType) {
+	err := h.HorizonClient.LoadMemo(payment)
+
+	if err != nil {
+		h.Logger.Error("Failed to load memo for payment", zap.Any("Payment", payment))
+	} else {
+		memo = null.NewString(payment.Memo.Value, payment.Memo.Value != "")
+
+		var ok bool
+		memoType, ok = stellar.ToMemoType(payment.Memo.Type)
+
+		if !ok || memoType != stellar.MemoTypeHash {
+			h.Logger.Info("Unable to parse ethereum address from invalid memo type",
+				zap.String("Memo Type", payment.Memo.Type),
+				zap.String("Memo Value", payment.Memo.Value),
+				zap.Any("Payment", payment),
+			)
+		} else {
+			address, err := stellar.ExtractMemoToEthereumAddress(payment.Memo.Type, payment.Memo.Value)
+			if err != nil {
+				h.Logger.Info("Unable to parse ethereum address from memo",
+					zap.Error(err),
+					zap.Any("Payment", payment),
+				)
+			} else {
+				ethAddress = &address
+			}
+		}
+	}
+
+	return
+}

--- a/packages/demo/bridge/services/identity/listener/main.go
+++ b/packages/demo/bridge/services/identity/listener/main.go
@@ -1,0 +1,13 @@
+package listener
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/stellar/go/clients/horizon"
+)
+
+type StellarPayments struct {
+	Logger     *zap.Logger
+	Fatalities chan error
+	Client     *horizon.Client
+}

--- a/packages/demo/bridge/services/identity/listener/stellar_payments.go
+++ b/packages/demo/bridge/services/identity/listener/stellar_payments.go
@@ -1,0 +1,36 @@
+package listener
+
+import (
+	"context"
+
+	"github.com/stellar/go/clients/horizon"
+	"go.uber.org/zap"
+	"gopkg.in/guregu/null.v3"
+)
+
+func (s *StellarPayments) Start(address string, cursor null.String, payments chan horizon.Payment) {
+	s.Logger.Debug("Starting stream of payment logs")
+
+	horizonAccount, err := s.Client.LoadAccount(address)
+	if err != nil {
+		s.Logger.Error("Failed to load destination account from horizon", zap.Error(err))
+		s.Fatalities <- err
+		return
+	}
+
+	var horizonCursor *horizon.Cursor
+	if cursor.Valid {
+		hCursor := horizon.Cursor(cursor.String)
+		horizonCursor = &hCursor
+	}
+
+	s.Logger.Info("Starting stream",
+		zap.String("Account", address),
+		zap.Any("Horizon cursor", cursor),
+	)
+	go func(client *horizon.Client, accountID string, cursor *horizon.Cursor, payments chan horizon.Payment) {
+		client.StreamPayments(context.Background(), horizonAccount.AccountID, cursor, func(payment horizon.Payment) {
+			payments <- payment
+		})
+	}(s.Client, horizonAccount.AccountID, horizonCursor, payments)
+}

--- a/packages/demo/bridge/services/identity/main.go
+++ b/packages/demo/bridge/services/identity/main.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/config"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/config/key"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/eventhandler"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/listener"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/support/zapencoder"
+	"github.com/stellar/go/clients/horizon"
+)
+
+func initLogger() *zap.Logger {
+	// First, define our level-handling logic.
+	highPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl >= zapcore.ErrorLevel
+	})
+	lowPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl < zapcore.ErrorLevel && lvl > zapcore.DebugLevel
+	})
+
+	// High-priority output should go to standard error,
+	// and low-priority output should go to standard out.
+	consoleDebugging := zapcore.Lock(os.Stdout)
+	consoleErrors := zapcore.Lock(os.Stderr)
+
+	consoleEncoderConfig := zap.NewDevelopmentEncoderConfig()
+	consoleEncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	consoleEncoder := zapencoder.NewPrettyConsoleEncoder(consoleEncoderConfig)
+
+	// Join the outputs, encoders, and level-handling functions into
+	// zapcore.Cores, then tee the cores together.
+	core := zapcore.NewTee(
+		zapcore.NewCore(consoleEncoder, consoleErrors, highPriority),
+		zapcore.NewCore(consoleEncoder, consoleDebugging, lowPriority),
+	)
+
+	// From a zapcore.Core, construct a Logger.
+	logger := zap.New(core).WithOptions(
+		zap.AddCaller(),
+	)
+	return logger.Named("Bridge")
+}
+
+func main() {
+	logger := initLogger()
+	defer logger.Sync()
+
+	_config, err := config.Init()
+	if err != nil {
+		logger.Fatal("Unable to initialize configuration", zap.Error(err))
+	}
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, os.Kill, syscall.SIGTERM)
+
+	dbClient, err := db.NewPostgresDB(_config.Database, logger.Named("DB"))
+	if err != nil {
+		logger.Fatal("Unable to initialize db client", zap.Error(err))
+	}
+
+	stellarKeypair, err := key.StellarKeypairFromSecret(_config.Keys.Stellar.DecryptedSecret)
+	if err != nil {
+		logger.Fatal("Unable to decode stellar keypair", zap.Error(err))
+	}
+
+	stellarAccount, err := dbClient.LoadStellarAccount(stellarKeypair.Address())
+	if err != nil {
+		logger.Fatal("Unable to load stellar account", zap.Error(err))
+	}
+
+	fatalities := make(chan error)
+	ethereumLinkRequests := make(chan db.LinkRequest)
+	stellarIncomingPayments := make(chan horizon.Payment)
+
+	horizonClient := &horizon.Client{
+		URL:  _config.Networks.Stellar.URL,
+		HTTP: http.DefaultClient,
+	}
+
+	stellarPaymentsListener := &listener.StellarPayments{
+		Logger:     logger.Named("StellarPaymentsListener"),
+		Fatalities: fatalities,
+		Client:     horizonClient,
+	}
+
+	go stellarPaymentsListener.Start(stellarAccount.Address, stellarAccount.Cursor, stellarIncomingPayments)
+
+	stellarPaymentHandler := &eventhandler.StellarPaymentHandler{
+		Logger:        logger.Named("StellarPaymentsHandler"),
+		DB:            dbClient,
+		Fatalities:    fatalities,
+		HorizonClient: horizonClient,
+		LinkRequests:  ethereumLinkRequests,
+	}
+
+	for {
+		select {
+		case err := <-fatalities:
+			logger.Error("Got error", zap.Error(err))
+			return
+		case payment := <-stellarIncomingPayments:
+			logger.Info("Payment received", zap.Any("Payment", payment))
+			go stellarPaymentHandler.Receive(stellarAccount, &payment)
+		case linkRequest := <-ethereumLinkRequests:
+			logger.Info("Link request received", zap.Any("Request", linkRequest))
+		case killSignal := <-interrupt:
+			logger.Debug("Got signal", zap.Any("signal", killSignal))
+			logger.Debug("Killing service")
+			return
+		}
+	}
+}

--- a/packages/demo/bridge/support/stellar/errors.go
+++ b/packages/demo/bridge/support/stellar/errors.go
@@ -1,0 +1,11 @@
+package stellar
+
+import (
+	"fmt"
+)
+
+// Errors
+var (
+	ErrInvalidMemoType   = fmt.Errorf("Invalid memo type")
+	ErrInvalidEthAddress = fmt.Errorf("Invalid ethereum address")
+)

--- a/packages/demo/bridge/support/stellar/main.go
+++ b/packages/demo/bridge/support/stellar/main.go
@@ -1,0 +1,55 @@
+package stellar
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type MemoType int64
+
+const (
+	_ MemoType = iota
+	MemoTypeText
+	MemoTypeID
+	MemoTypeHash
+	MemoTypeReturn
+)
+
+func ToMemoType(memoType string) (MemoType, bool) {
+	switch memoType {
+	case "text":
+		return MemoTypeText, true
+	case "id":
+		return MemoTypeID, true
+	case "hash":
+		return MemoTypeHash, true
+	case "return":
+		return MemoTypeReturn, true
+	default:
+		return 0, false
+	}
+}
+
+func ExtractMemoToEthereumAddress(memoType, memoValue string) (ethAddress string, err error) {
+	switch memoType {
+	case "hash":
+		memoBytes, err := base64.StdEncoding.DecodeString(memoValue)
+		if err != nil {
+			return "", err
+		}
+		if len(memoBytes) != 32 {
+			return "", ErrInvalidEthAddress
+		}
+
+		address := hex.EncodeToString(memoBytes[12:])
+		if !common.IsHexAddress(address) {
+			return "", ErrInvalidEthAddress
+		}
+
+		return address, nil
+	default:
+		return "", ErrInvalidMemoType
+	}
+}

--- a/packages/demo/bridge/support/zapencoder/console_encoder.go
+++ b/packages/demo/bridge/support/zapencoder/console_encoder.go
@@ -1,0 +1,130 @@
+package zapencoder
+
+import (
+	"fmt"
+	"sync"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+var _sliceEncoderPool = sync.Pool{
+	New: func() interface{} {
+		return &sliceArrayEncoder{elems: make([]interface{}, 0, 2)}
+	},
+}
+
+func getSliceEncoder() *sliceArrayEncoder {
+	return _sliceEncoderPool.Get().(*sliceArrayEncoder)
+}
+
+func putSliceEncoder(e *sliceArrayEncoder) {
+	e.elems = e.elems[:0]
+	_sliceEncoderPool.Put(e)
+}
+
+type consoleEncoder struct {
+	*prettyJSONEncoder
+}
+
+// NewPrettyConsoleEncoder creates an encoder whose output is designed for human
+// - rather than machine - consumption. It serializes the core log entry data
+// (message, level, timestamp, etc.) in a plain-text format and leaves the
+// structured context as prettified JSON.
+//
+// Note that although the console encoder doesn't use the keys specified in the
+// encoder configuration, it will omit any element whose key is set to the empty
+// string.
+func NewPrettyConsoleEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
+	return consoleEncoder{newJSONEncoder(cfg, true)}
+}
+
+func (c consoleEncoder) Clone() zapcore.Encoder {
+	return consoleEncoder{c.prettyJSONEncoder.Clone().(*prettyJSONEncoder)}
+}
+
+func (c consoleEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	line := BufferGet()
+
+	// We don't want the entry's metadata to be quoted and escaped (if it's
+	// encoded as strings), which means that we can't use the JSON encoder. The
+	// simplest option is to use the memory encoder and fmt.Fprint.
+	//
+	// If this ever becomes a performance bottleneck, we can implement
+	// ArrayEncoder for our plain-text format.
+	arr := getSliceEncoder()
+	if c.TimeKey != "" && c.EncodeTime != nil {
+		c.EncodeTime(ent.Time, arr)
+	}
+	if c.LevelKey != "" && c.EncodeLevel != nil {
+		c.EncodeLevel(ent.Level, arr)
+	}
+	if ent.LoggerName != "" && c.NameKey != "" {
+		nameEncoder := c.EncodeName
+
+		if nameEncoder == nil {
+			// Fall back to FullNameEncoder for backward compatibility.
+			nameEncoder = zapcore.FullNameEncoder
+		}
+
+		nameEncoder(ent.LoggerName, arr)
+	}
+	if ent.Caller.Defined && c.CallerKey != "" && c.EncodeCaller != nil {
+		c.EncodeCaller(ent.Caller, arr)
+	}
+	for i := range arr.elems {
+		if i > 0 {
+			line.AppendByte('\t')
+		}
+		fmt.Fprint(line, arr.elems[i])
+	}
+	putSliceEncoder(arr)
+
+	// Add the message itself.
+	if c.MessageKey != "" {
+		c.addTabIfNecessary(line)
+		line.AppendString(ent.Message)
+	}
+
+	// Add any structured context.
+	c.writeContext(line, fields)
+
+	// If there's no stacktrace key, honor that; this allows users to force
+	// single-line output.
+	if ent.Stack != "" && c.StacktraceKey != "" {
+		line.AppendByte('\n')
+		line.AppendString(ent.Stack)
+	}
+
+	if c.LineEnding != "" {
+		line.AppendString(c.LineEnding)
+	} else {
+		line.AppendString(zapcore.DefaultLineEnding)
+	}
+	return line, nil
+}
+
+func (c consoleEncoder) writeContext(line *buffer.Buffer, extra []zapcore.Field) {
+	context := c.prettyJSONEncoder.Clone().(*prettyJSONEncoder)
+	defer context.buf.Free()
+
+	for i := range extra {
+		extra[i].AddTo(context)
+	}
+
+	context.closeOpenNamespaces()
+	if context.buf.Len() == 0 {
+		return
+	}
+
+	line.AppendByte('\n')
+	line.AppendByte('\n')
+	line.Write(context.buf.Bytes())
+	line.AppendByte('\n')
+}
+
+func (c consoleEncoder) addTabIfNecessary(line *buffer.Buffer) {
+	if line.Len() > 0 {
+		line.AppendByte('\t')
+	}
+}

--- a/packages/demo/bridge/support/zapencoder/formatter.go
+++ b/packages/demo/bridge/support/zapencoder/formatter.go
@@ -1,0 +1,190 @@
+package zapencoder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+)
+
+// Formatter is a struct to format JSON data. `color` is github.com/fatih/color: https://github.com/fatih/color
+type Formatter struct {
+	// JSON key color. Default is `color.New(color.FgBlue, color.Bold)`.
+	KeyColor *color.Color
+
+	// JSON string value color. Default is `color.New(color.FgGreen, color.Bold)`.
+	StringColor *color.Color
+
+	// JSON boolean value color. Default is `color.New(color.FgYellow, color.Bold)`.
+	BoolColor *color.Color
+
+	// JSON number value color. Default is `color.New(color.FgCyan, color.Bold)`.
+	NumberColor *color.Color
+
+	// JSON null value color. Default is `color.New(color.FgBlack, color.Bold)`.
+	NullColor *color.Color
+
+	// Max length of JSON string value. When the value is 1 and over, string is truncated to length of the value.
+	// Default is 0 (not truncated).
+	StringMaxLength int
+
+	// Boolean to disable color. Default is false.
+	DisabledColor bool
+
+	// Indent space number. Default is 2.
+	Indent int
+
+	// Newline string. To print without new lines set it to empty string. Default is \n.
+	Newline string
+}
+
+// NewFormatter returns a new formatter with following default values.
+func NewFormatter() *Formatter {
+	return &Formatter{
+		KeyColor:        color.New(color.FgBlue, color.Bold),
+		StringColor:     color.New(color.FgGreen, color.Bold),
+		BoolColor:       color.New(color.FgYellow, color.Bold),
+		NumberColor:     color.New(color.FgCyan, color.Bold),
+		NullColor:       color.New(color.FgBlack, color.Bold),
+		StringMaxLength: 0,
+		DisabledColor:   false,
+		Indent:          2,
+		Newline:         "\n",
+	}
+}
+
+// Marshal marshals and formats JSON data.
+func (f *Formatter) Marshal(v interface{}) ([]byte, error) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	return f.Format(data)
+}
+
+// Format formats JSON string.
+func (f *Formatter) Format(data []byte) ([]byte, error) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, err
+	}
+
+	return []byte(f.pretty(v, 1)), nil
+}
+
+func (f *Formatter) sprintfColor(c *color.Color, format string, args ...interface{}) string {
+	if f.DisabledColor || c == nil {
+		return fmt.Sprintf(format, args...)
+	}
+	return c.SprintfFunc()(format, args...)
+}
+
+func (f *Formatter) sprintColor(c *color.Color, s string) string {
+	if f.DisabledColor || c == nil {
+		return fmt.Sprint(s)
+	}
+	return c.SprintFunc()(s)
+}
+
+func (f *Formatter) pretty(v interface{}, depth int) string {
+	switch val := v.(type) {
+	case string:
+		return f.processString(val)
+	case float64:
+		return f.sprintColor(f.NumberColor, strconv.FormatFloat(val, 'f', -1, 64))
+	case bool:
+		return f.sprintColor(f.BoolColor, strconv.FormatBool(val))
+	case nil:
+		return f.sprintColor(f.NullColor, "null")
+	case map[string]interface{}:
+		return f.processMap(val, depth)
+	case []interface{}:
+		return f.processArray(val, depth)
+	}
+
+	return ""
+}
+
+func (f *Formatter) processString(s string) string {
+	r := []rune(s)
+	if f.StringMaxLength != 0 && len(r) >= f.StringMaxLength {
+		s = string(r[0:f.StringMaxLength]) + "..."
+	}
+
+	buf := &bytes.Buffer{}
+	encoder := json.NewEncoder(buf)
+	encoder.SetEscapeHTML(false)
+	encoder.Encode(s)
+	s = string(buf.Bytes())
+	s = strings.TrimSuffix(s, "\n")
+
+	return f.sprintColor(f.StringColor, s)
+}
+
+func (f *Formatter) processMap(m map[string]interface{}, depth int) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+
+	currentIndent := f.generateIndent(depth - 1)
+	nextIndent := f.generateIndent(depth)
+	rows := []string{}
+	keys := []string{}
+
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val := m[key]
+		k := f.sprintfColor(f.KeyColor, `"%s"`, key)
+		v := f.pretty(val, depth+1)
+
+		valueIndent := " "
+		if f.Newline == "" {
+			valueIndent = ""
+		}
+		row := fmt.Sprintf("%s%s:%s%s", nextIndent, k, valueIndent, v)
+		rows = append(rows, row)
+	}
+
+	return fmt.Sprintf("{%s%s%s%s}", f.Newline, strings.Join(rows, ","+f.Newline), f.Newline, currentIndent)
+}
+
+func (f *Formatter) processArray(a []interface{}, depth int) string {
+	if len(a) == 0 {
+		return "[]"
+	}
+
+	currentIndent := f.generateIndent(depth - 1)
+	nextIndent := f.generateIndent(depth)
+	rows := []string{}
+
+	for _, val := range a {
+		c := f.pretty(val, depth+1)
+		row := nextIndent + c
+		rows = append(rows, row)
+	}
+	return fmt.Sprintf("[%s%s%s%s]", f.Newline, strings.Join(rows, ","+f.Newline), f.Newline, currentIndent)
+}
+
+func (f *Formatter) generateIndent(depth int) string {
+	return strings.Repeat(" ", f.Indent*depth)
+}
+
+// Marshal JSON data with default options.
+func Marshal(v interface{}) ([]byte, error) {
+	return NewFormatter().Marshal(v)
+}
+
+// Format JSON string with default options.
+func Format(data []byte) ([]byte, error) {
+	return NewFormatter().Format(data)
+}

--- a/packages/demo/bridge/support/zapencoder/memory_encoder.go
+++ b/packages/demo/bridge/support/zapencoder/memory_encoder.go
@@ -1,0 +1,53 @@
+package zapencoder
+
+import (
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// sliceArrayEncoder is an ArrayEncoder backed by a simple []interface{}. Like
+// the MapObjectEncoder, it's not designed for production use.
+type sliceArrayEncoder struct {
+	elems []interface{}
+}
+
+func (s *sliceArrayEncoder) AppendArray(v zapcore.ArrayMarshaler) error {
+	enc := &sliceArrayEncoder{}
+	err := v.MarshalLogArray(enc)
+	s.elems = append(s.elems, enc.elems)
+	return err
+}
+
+func (s *sliceArrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
+	m := zapcore.NewMapObjectEncoder()
+	err := v.MarshalLogObject(m)
+	s.elems = append(s.elems, m.Fields)
+	return err
+}
+
+func (s *sliceArrayEncoder) AppendReflected(v interface{}) error {
+	s.elems = append(s.elems, v)
+	return nil
+}
+
+func (s *sliceArrayEncoder) AppendBool(v bool)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendByteString(v []byte)      { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendComplex128(v complex128)  { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendComplex64(v complex64)    { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendDuration(v time.Duration) { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendFloat64(v float64)        { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendFloat32(v float32)        { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt(v int)                { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt64(v int64)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt32(v int32)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt16(v int16)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendInt8(v int8)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendString(v string)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendTime(v time.Time)         { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint(v uint)              { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint64(v uint64)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint32(v uint32)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint16(v uint16)          { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUint8(v uint8)            { s.elems = append(s.elems, v) }
+func (s *sliceArrayEncoder) AppendUintptr(v uintptr)        { s.elems = append(s.elems, v) }

--- a/packages/demo/bridge/support/zapencoder/pretty_encoder.go
+++ b/packages/demo/bridge/support/zapencoder/pretty_encoder.go
@@ -1,0 +1,426 @@
+package zapencoder
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	_pool = buffer.NewPool()
+	// BufferGet retrieves a buffer from the pool, creating one if necessary.
+	BufferGet = _pool.Get
+)
+
+var _jsonPool = sync.Pool{New: func() interface{} {
+	return &prettyJSONEncoder{}
+}}
+
+func getJSONEncoder() *prettyJSONEncoder {
+	return _jsonPool.Get().(*prettyJSONEncoder)
+}
+
+func putJSONEncoder(enc *prettyJSONEncoder) {
+	if enc.reflectBuf != nil {
+		enc.reflectBuf.Free()
+	}
+	enc.EncoderConfig = nil
+	enc.buf = nil
+	enc.spaced = false
+	enc.openNamespaces = 0
+	enc.reflectBuf = nil
+	enc.reflectEnc = nil
+	_jsonPool.Put(enc)
+}
+
+type prettyJSONEncoder struct {
+	*zapcore.EncoderConfig
+	*Formatter
+	buf            *buffer.Buffer
+	spaced         bool // include spaces after colons and commas
+	openNamespaces int
+	indent         int
+
+	// for encoding generic values by reflection
+	reflectBuf *buffer.Buffer
+	reflectEnc *json.Encoder
+}
+
+// NewJSONEncoder creates a fast, low-allocation JSON encoder. The encoder
+// appropriately escapes all field keys and values.
+//
+// Note that the encoder doesn't deduplicate keys, so it's possible to produce
+// a message like
+//   {"foo":"bar","foo":"baz"}
+// This is permitted by the JSON specification, but not encouraged. Many
+// libraries will ignore duplicate key-value pairs (typically keeping the last
+// pair) when unmarshaling, but users should attempt to avoid adding duplicate
+// keys.
+func NewJSONEncoder(cfg zapcore.EncoderConfig) zapcore.Encoder {
+	return newJSONEncoder(cfg, false)
+}
+
+func newJSONEncoder(cfg zapcore.EncoderConfig, spaced bool) *prettyJSONEncoder {
+	return &prettyJSONEncoder{
+		EncoderConfig: &cfg,
+		Formatter:     NewFormatter(),
+		buf:           BufferGet(),
+		spaced:        spaced,
+		indent:        1,
+	}
+}
+
+func (enc *prettyJSONEncoder) AddArray(key string, arr zapcore.ArrayMarshaler) error {
+	enc.addKey(key)
+	return enc.AppendArray(arr)
+}
+
+func (enc *prettyJSONEncoder) AddObject(key string, obj zapcore.ObjectMarshaler) error {
+	enc.addKey(key)
+	return enc.AppendObject(obj)
+}
+
+func (enc *prettyJSONEncoder) AddBinary(key string, val []byte) {
+	enc.AddString(key, base64.StdEncoding.EncodeToString(val))
+}
+
+func (enc *prettyJSONEncoder) AddByteString(key string, val []byte) {
+	enc.addKey(key)
+	enc.AppendByteString(val)
+}
+
+func (enc *prettyJSONEncoder) AddBool(key string, val bool) {
+	enc.addKey(key)
+	enc.AppendBool(val)
+}
+
+func (enc *prettyJSONEncoder) AddComplex128(key string, val complex128) {
+	enc.addKey(key)
+	enc.AppendComplex128(val)
+}
+
+func (enc *prettyJSONEncoder) AddDuration(key string, val time.Duration) {
+	enc.addKey(key)
+	enc.AppendDuration(val)
+}
+
+func (enc *prettyJSONEncoder) AddFloat64(key string, val float64) {
+	enc.addKey(key)
+	enc.AppendFloat64(val)
+}
+
+func (enc *prettyJSONEncoder) AddInt64(key string, val int64) {
+	enc.addKey(key)
+	enc.AppendInt64(val)
+}
+
+func (enc *prettyJSONEncoder) resetReflectBuf() {
+	if enc.reflectBuf == nil {
+		enc.reflectBuf = BufferGet()
+		enc.reflectEnc = json.NewEncoder(enc.reflectBuf)
+	} else {
+		enc.reflectBuf.Reset()
+	}
+}
+
+func (enc *prettyJSONEncoder) AddReflected(key string, obj interface{}) error {
+	enc.resetReflectBuf()
+	err := enc.reflectEnc.Encode(obj)
+	if err != nil {
+		return err
+	}
+	enc.reflectBuf.TrimNewline()
+	enc.addKey(key)
+	_, err = enc.buf.Write(enc.reflectBuf.Bytes())
+	return err
+}
+
+func (enc *prettyJSONEncoder) OpenNamespace(key string) {
+	enc.addKey(key)
+	enc.buf.AppendByte('{')
+	enc.openNamespaces++
+}
+
+func (enc *prettyJSONEncoder) AddString(key, val string) {
+	enc.addKey(key)
+	enc.AppendString(val)
+}
+
+func (enc *prettyJSONEncoder) AddTime(key string, val time.Time) {
+	enc.addKey(key)
+	enc.AppendTime(val)
+}
+
+func (enc *prettyJSONEncoder) AddUint64(key string, val uint64) {
+	enc.addKey(key)
+	enc.AppendUint64(val)
+}
+
+func (enc *prettyJSONEncoder) AppendArray(arr zapcore.ArrayMarshaler) error {
+	enc.addElementSeparator()
+	enc.buf.AppendByte('[')
+	enc.buf.AppendByte('\n')
+	enc.indent++
+	err := arr.MarshalLogArray(enc)
+	enc.indent--
+	enc.buf.AppendByte('\n')
+	enc.buf.AppendString(strings.Repeat("\t", enc.indent))
+	enc.buf.AppendByte(']')
+	return err
+}
+
+func (enc *prettyJSONEncoder) AppendObject(obj zapcore.ObjectMarshaler) error {
+	enc.addElementSeparator()
+
+	if last := enc.buf.Len() - 1; last >= 0 {
+		if enc.buf.Bytes()[last] == '\n' {
+			enc.buf.AppendString(strings.Repeat("\t", enc.indent))
+		}
+	}
+
+	enc.buf.AppendByte('{')
+	enc.buf.AppendByte('\n')
+	enc.indent++
+	err := obj.MarshalLogObject(enc)
+	enc.indent--
+	enc.buf.AppendByte('\n')
+	enc.buf.AppendString(strings.Repeat("\t", enc.indent))
+	enc.buf.AppendByte('}')
+	return err
+}
+
+func (enc *prettyJSONEncoder) AppendBool(val bool) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(enc.sprintfColor(enc.BoolColor, "%v", val))
+}
+
+func (enc *prettyJSONEncoder) AppendByteString(val []byte) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(enc.sprintfColor(enc.StringColor, "\"%s\"", val))
+}
+
+func (enc *prettyJSONEncoder) AppendComplex128(val complex128) {
+	enc.addElementSeparator()
+	// Cast to a platform-independent, fixed-size type.
+	r, i := float64(real(val)), float64(imag(val))
+	enc.buf.AppendString(enc.sprintfColor(
+		enc.NumberColor,
+		"\"%s+%si\"",
+		strconv.FormatFloat(r, 'f', -1, 64),
+		strconv.FormatFloat(i, 'f', -1, 64),
+	))
+}
+
+func (enc *prettyJSONEncoder) AppendDuration(val time.Duration) {
+	cur := enc.buf.Len()
+	enc.EncodeDuration(val, enc)
+	if cur == enc.buf.Len() {
+		// User-supplied EncodeDuration is a no-op. Fall back to nanoseconds to keep
+		// JSON valid.
+		enc.AppendInt64(int64(val))
+	}
+}
+
+func (enc *prettyJSONEncoder) AppendInt64(val int64) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(enc.sprintfColor(enc.NumberColor, "%d", val))
+}
+
+func (enc *prettyJSONEncoder) AppendReflected(val interface{}) error {
+	enc.resetReflectBuf()
+	err := enc.reflectEnc.Encode(val)
+	if err != nil {
+		return err
+	}
+	enc.reflectBuf.TrimNewline()
+	enc.addElementSeparator()
+	_, err = enc.buf.Write(enc.reflectBuf.Bytes())
+	return err
+}
+
+func (enc *prettyJSONEncoder) AppendString(val string) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(enc.sprintfColor(enc.StringColor, "\"%s\"", val))
+}
+
+func (enc *prettyJSONEncoder) AppendTime(val time.Time) {
+	cur := enc.buf.Len()
+	enc.EncodeTime(val, enc)
+	if cur == enc.buf.Len() {
+		// User-supplied EncodeTime is a no-op. Fall back to nanos since epoch to keep
+		// output JSON valid.
+		enc.AppendInt64(val.UnixNano())
+	}
+}
+
+func (enc *prettyJSONEncoder) AppendUint64(val uint64) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(enc.sprintfColor(enc.NumberColor, "%d", val))
+}
+
+func (enc *prettyJSONEncoder) AddComplex64(k string, v complex64) { enc.AddComplex128(k, complex128(v)) }
+func (enc *prettyJSONEncoder) AddFloat32(k string, v float32)     { enc.AddFloat64(k, float64(v)) }
+func (enc *prettyJSONEncoder) AddInt(k string, v int)             { enc.AddInt64(k, int64(v)) }
+func (enc *prettyJSONEncoder) AddInt32(k string, v int32)         { enc.AddInt64(k, int64(v)) }
+func (enc *prettyJSONEncoder) AddInt16(k string, v int16)         { enc.AddInt64(k, int64(v)) }
+func (enc *prettyJSONEncoder) AddInt8(k string, v int8)           { enc.AddInt64(k, int64(v)) }
+func (enc *prettyJSONEncoder) AddUint(k string, v uint)           { enc.AddUint64(k, uint64(v)) }
+func (enc *prettyJSONEncoder) AddUint32(k string, v uint32)       { enc.AddUint64(k, uint64(v)) }
+func (enc *prettyJSONEncoder) AddUint16(k string, v uint16)       { enc.AddUint64(k, uint64(v)) }
+func (enc *prettyJSONEncoder) AddUint8(k string, v uint8)         { enc.AddUint64(k, uint64(v)) }
+func (enc *prettyJSONEncoder) AddUintptr(k string, v uintptr)     { enc.AddUint64(k, uint64(v)) }
+func (enc *prettyJSONEncoder) AppendComplex64(v complex64)        { enc.AppendComplex128(complex128(v)) }
+func (enc *prettyJSONEncoder) AppendFloat64(v float64)            { enc.appendFloat(v, 64) }
+func (enc *prettyJSONEncoder) AppendFloat32(v float32)            { enc.appendFloat(float64(v), 32) }
+func (enc *prettyJSONEncoder) AppendInt(v int)                    { enc.AppendInt64(int64(v)) }
+func (enc *prettyJSONEncoder) AppendInt32(v int32)                { enc.AppendInt64(int64(v)) }
+func (enc *prettyJSONEncoder) AppendInt16(v int16)                { enc.AppendInt64(int64(v)) }
+func (enc *prettyJSONEncoder) AppendInt8(v int8)                  { enc.AppendInt64(int64(v)) }
+func (enc *prettyJSONEncoder) AppendUint(v uint)                  { enc.AppendUint64(uint64(v)) }
+func (enc *prettyJSONEncoder) AppendUint32(v uint32)              { enc.AppendUint64(uint64(v)) }
+func (enc *prettyJSONEncoder) AppendUint16(v uint16)              { enc.AppendUint64(uint64(v)) }
+func (enc *prettyJSONEncoder) AppendUint8(v uint8)                { enc.AppendUint64(uint64(v)) }
+func (enc *prettyJSONEncoder) AppendUintptr(v uintptr)            { enc.AppendUint64(uint64(v)) }
+
+func (enc *prettyJSONEncoder) Clone() zapcore.Encoder {
+	clone := enc.clone()
+	clone.buf.Write(enc.buf.Bytes())
+	return clone
+}
+
+func (enc *prettyJSONEncoder) clone() *prettyJSONEncoder {
+	clone := getJSONEncoder()
+	clone.EncoderConfig = enc.EncoderConfig
+	clone.Formatter = enc.Formatter
+	clone.spaced = enc.spaced
+	clone.indent = enc.indent
+	clone.openNamespaces = enc.openNamespaces
+	clone.buf = BufferGet()
+	return clone
+}
+
+func (enc *prettyJSONEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	final := enc.clone()
+	final.buf.AppendByte('{')
+
+	if final.LevelKey != "" {
+		final.addKey(final.LevelKey)
+		cur := final.buf.Len()
+		final.EncodeLevel(ent.Level, final)
+		if cur == final.buf.Len() {
+			// User-supplied EncodeLevel was a no-op. Fall back to strings to keep
+			// output JSON valid.
+			final.AppendString(ent.Level.String())
+		}
+	}
+	if final.TimeKey != "" {
+		final.AddTime(final.TimeKey, ent.Time)
+	}
+	if ent.LoggerName != "" && final.NameKey != "" {
+		final.addKey(final.NameKey)
+		cur := final.buf.Len()
+		nameEncoder := final.EncodeName
+
+		// if no name encoder provided, fall back to FullNameEncoder for backwards
+		// compatibility
+		if nameEncoder == nil {
+			nameEncoder = zapcore.FullNameEncoder
+		}
+
+		nameEncoder(ent.LoggerName, final)
+		if cur == final.buf.Len() {
+			// User-supplied EncodeName was a no-op. Fall back to strings to
+			// keep output JSON valid.
+			final.AppendString(ent.LoggerName)
+		}
+	}
+	if ent.Caller.Defined && final.CallerKey != "" {
+		final.addKey(final.CallerKey)
+		cur := final.buf.Len()
+		final.EncodeCaller(ent.Caller, final)
+		if cur == final.buf.Len() {
+			// User-supplied EncodeCaller was a no-op. Fall back to strings to
+			// keep output JSON valid.
+			final.AppendString(ent.Caller.String())
+		}
+	}
+	if final.MessageKey != "" {
+		final.addKey(enc.MessageKey)
+		final.AppendString(ent.Message)
+	}
+	if enc.buf.Len() > 0 {
+		final.addElementSeparator()
+		final.buf.Write(enc.buf.Bytes())
+	}
+	for i := range fields {
+		fields[i].AddTo(final)
+	}
+	final.closeOpenNamespaces()
+	if ent.Stack != "" && final.StacktraceKey != "" {
+		final.AddString(final.StacktraceKey, ent.Stack)
+	}
+	final.buf.AppendByte('}')
+	if final.LineEnding != "" {
+		final.buf.AppendString(final.LineEnding)
+	} else {
+		final.buf.AppendString(zapcore.DefaultLineEnding)
+	}
+
+	ret := final.buf
+	putJSONEncoder(final)
+	return ret, nil
+}
+
+func (enc *prettyJSONEncoder) truncate() {
+	enc.buf.Reset()
+}
+
+func (enc *prettyJSONEncoder) closeOpenNamespaces() {
+	for i := 0; i < enc.openNamespaces; i++ {
+		enc.buf.AppendByte('}')
+	}
+}
+
+func (enc *prettyJSONEncoder) addKey(key string) {
+	enc.addElementSeparator()
+	enc.buf.AppendString(strings.Repeat("\t", enc.indent))
+	enc.buf.AppendString(enc.sprintfColor(enc.KeyColor, "\"%s\"", key))
+	enc.buf.AppendByte(':')
+	if enc.spaced {
+		enc.buf.AppendByte(' ')
+	}
+}
+
+func (enc *prettyJSONEncoder) addElementSeparator() {
+	last := enc.buf.Len() - 1
+	if last < 0 {
+		return
+	}
+	switch enc.buf.Bytes()[last] {
+	case '{', '[', ':', '\n', '\t', ' ':
+		return
+	default:
+		enc.buf.AppendByte('\n')
+	}
+}
+
+func (enc *prettyJSONEncoder) appendFloat(val float64, bitSize int) {
+	enc.addElementSeparator()
+	switch {
+	case math.IsNaN(val):
+		enc.buf.AppendString(enc.sprintColor(enc.NumberColor, `"NaN"`))
+	case math.IsInf(val, 1):
+		enc.buf.AppendString(enc.sprintColor(enc.NumberColor, `"+Inf"`))
+	case math.IsInf(val, -1):
+		enc.buf.AppendString(enc.sprintColor(enc.NumberColor, `"-Inf"`))
+	default:
+		enc.buf.AppendString(enc.sprintColor(enc.NumberColor, strconv.FormatFloat(val, 'f', -1, bitSize)))
+	}
+}


### PR DESCRIPTION
# New packages
- Add `services/identity/db` package for `Database` interface/implementations and model structs.
- Add `services/identity/listener` package for listeners such as:
  - Stellar payments streaming
  - Worker job to create link requests based on incoming stellar payments (not implemented)
  - Ethereum smart contract events (not implemented)
- Add `services/identity/eventhandler` package for event handlers such as:
  - Incoming stellar payments
  - New link requests (not implemented)
  - New ethereum smart contract events (not implemented)
- Add `support/zapencoder` package, which is a modified version of `zap`'s encoder for pretty printing.
- Add `support/stellar` package for stellar utilities such as the  extraction and validation of ethereum address from stellar transaction memo.

# Features
- Listen to stellar events, record into database.
- Validates the ethereum address from the transaction memo, stores the status of the validation.