### PR TITLE
Change identities contracts address storage in identity registry

### DIFF
--- a/packages/ethereum-contracts/contracts/identity/IdentityRegistry.sol
+++ b/packages/ethereum-contracts/contracts/identity/IdentityRegistry.sol
@@ -25,8 +25,8 @@ contract IdentityRegistry is Ownable {
         keyEnums = _keyEnums;
     }
 
-    // Mapping from ethereum wallet to ERC725 + ERC735 identity
-    mapping (address => address) public identities;
+    // All identity contracts
+    mapping (address => bool) public identities;
 
     // Mapping of networks to identity accounts, i.e. Ethereum = 1, Stellar = 2
     mapping (uint256 => IdentityAccounts) public networkAccounts;
@@ -42,27 +42,15 @@ contract IdentityRegistry is Ownable {
             ethIdentityAccounts != address(0),
             "Ethereum identity accounts is not set"
         );
-        require(identities[msg.sender] == address(0), "Identity exists");
         Identity newIdentity = new Identity(msg.sender, keyEnums);
-        identities[msg.sender] = newIdentity;
+        require(identities[newIdentity] == false, "Identity exists");
+        identities[newIdentity] = true;
 
         ethIdentityAccounts.newIdentity(newIdentity, msg.sender);
 
         emit NewIdentity(msg.sender, newIdentity);
 
         return newIdentity;
-    }
-
-    /**
-     * @dev Checks whether an identity exists in the registry
-     * @param addr The identity contract address to check for
-     */
-    function hasIdentity(address addr)
-        public
-        view
-        returns (bool)
-    {
-        return identities[addr] != address(0);
     }
 
     function setEthereumIdentityAccounts(EthereumIdentityAccounts acc)

--- a/packages/ethereum-contracts/test/identity/identityRegistry.js
+++ b/packages/ethereum-contracts/test/identity/identityRegistry.js
@@ -86,7 +86,7 @@ contract('IdentityRegistry Test', async (addrs) => {
             });
 
             it('should have registered identity', async () => {
-                assert.isTrue(await registry.hasIdentity(addrs[0]));
+                assert.isTrue(await registry.identities(identity.address));
             });
 
             it('should have keys', async () => {


### PR DESCRIPTION
The storage of all identity contracts were previously done with a mapping of `msg.sender` to the new contract address. The implementation has a few issues:
- It does not allow us to check whether an identity contract is in the registry.
- There is no meaning in storing who created the identity. If we need to map an owner address to the identity contract, then that is already stored in the `EthereumIdentityAccounts` contract.

To allow querying of whether an address is an identity contract under the registry, the mapping will be changed to the newly created contract address to a boolean. This replaces the `hasIdentity` function.