### PR TITLE
Change gas limit to more reasonable amount

### DIFF
--- a/packages/ethereum-contracts/truffle.js
+++ b/packages/ethereum-contracts/truffle.js
@@ -16,19 +16,19 @@ module.exports = {
         },
         ropsten: {
             provider: () => new HDWalletProvider(secrets.MNEMONIC, `https://ropsten.infura.io/${secrets.INFURA_KEY}`),
-            gas: 4700000,
+            gas: 6700000,
             gasPrice: 3000000000,
             network_id: 3,
         },
         rinkeby: {
             provider: () => new HDWalletProvider(secrets.MNEMONIC, `https://rinkeby.infura.io/${secrets.INFURA_KEY}`),
-            gas: 4700000,
+            gas: 6700000,
             gasPrice: 3000000000,
             network_id: 4,
         },
         kovan: {
             provider: () => new HDWalletProvider(secrets.MNEMONIC, `https://kovan.infura.io/${secrets.INFURA_KEY}`),
-            gas: 4700000,
+            gas: 6700000,
             gasPrice: 3000000000,
             network_id: 42,
         },


### PR DESCRIPTION
As above. Ropsten updated block limit to 8000000 gas, so a 6700000 gas limit seems reasonable. One of our contracts need > 5000000 gas right now.