### PR TITLE
Ethereum contract calling and listening for identity bridge service

### DIFF
--- a/packages/demo/bridge/Gopkg.lock
+++ b/packages/demo/bridge/Gopkg.lock
@@ -22,6 +22,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:7d191fd0c54ff370eaf6116a14dafe2a328df487baea280699f597aae858d00d"
+  name = "github.com/aristanetworks/goarista"
+  packages = ["monotime"]
+  pruneopts = "UT"
+  revision = "33151c4543a79b013e8e6799ef45b2ba88c3cd1c"
+
+[[projects]]
+  branch = "master"
   digest = "1:c0decf632843204d2b8781de7b26e7038584e2dcccc7e2f401e88ae85b1df2b7"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
@@ -37,16 +45,41 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:e86a5143f0976522cbd4e41eb8ab186a81a98f8c28bf52a4234b80ecf48ab934"
+  digest = "1:e47d51dab652d26c3fba6f8cba403f922d02757a82abdc77e90df7948daf296e"
+  name = "github.com/deckarep/golang-set"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "cbaa98ba5575e67703b32b4b19f73c91f3c4159e"
+  version = "v1.7.1"
+
+[[projects]]
+  digest = "1:157ad8964124f4baaaf6d4d8b6434bc3db1cb43936c7ad665bb73d2b2a0d2c2b"
   name = "github.com/ethereum/go-ethereum"
   packages = [
+    ".",
+    "accounts",
+    "accounts/abi",
+    "accounts/abi/bind",
+    "accounts/keystore",
     "common",
     "common/hexutil",
     "common/math",
+    "common/mclock",
+    "common/prque",
+    "core/types",
     "crypto",
     "crypto/secp256k1",
     "crypto/sha3",
+    "ethclient",
+    "ethdb",
+    "event",
+    "log",
+    "metrics",
+    "p2p/netutil",
+    "params",
     "rlp",
+    "rpc",
+    "trie",
   ]
   pruneopts = "UT"
   revision = "8bbe72075e4e16442c4e28d999edee12e294329e"
@@ -69,6 +102,14 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:586ea76dbd0374d6fb649a91d70d652b7fe0ccffb8910a77468e7702e7901f3d"
+  name = "github.com/go-stack/stack"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
+
+[[projects]]
   digest = "1:083bd57e1a2b764eb19b70e7816bc1385b30d73191540e2756dceb445eff2eb2"
   name = "github.com/gocraft/dbr"
   packages = [
@@ -78,6 +119,22 @@
   pruneopts = "UT"
   revision = "b542ddb88301820e373c3152d83dd6cab8786985"
   version = "v2.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4a0c6bb4805508a6287675fac876be2ac1182539ca8a32468d8128882e9d5009"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  digest = "1:3a26588bc48b96825977c1b3df964f8fd842cd6860cc26370588d3563433cf11"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
@@ -115,6 +172,14 @@
   version = "v0.0.4"
 
 [[projects]]
+  digest = "1:e5d0bd87abc2781d14e274807a470acd180f0499f8bf5bb18606e9ec22ad9de9"
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
+
+[[projects]]
   digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
@@ -129,6 +194,22 @@
   pruneopts = "UT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:31d83d1b1c288073c91abadee3caec87de2a1fb5dbe589039264a802e67a26b8"
+  name = "github.com/rjeczalik/notify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "69d839f37b13a8cb7a78366f7633a4071cb43be7"
+  version = "v0.9.2"
+
+[[projects]]
+  digest = "1:b0c25f00bad20d783d259af2af8666969e2fc343fa0dc9efe52936bbd67fb758"
+  name = "github.com/rs/cors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
 
 [[projects]]
   digest = "1:54bd573538ca13ccf85d18c99249d934f17957f17263256b42565a11c854c1de"
@@ -205,6 +286,27 @@
   version = "v1.2.2"
 
 [[projects]]
+  branch = "master"
+  digest = "1:59483b8e8183f10ab21a85ba1f4cbb4a2335d48891801f79ed7b9499f44d383c"
+  name = "github.com/syndtr/goleveldb"
+  packages = [
+    "leveldb",
+    "leveldb/cache",
+    "leveldb/comparer",
+    "leveldb/errors",
+    "leveldb/filter",
+    "leveldb/iterator",
+    "leveldb/journal",
+    "leveldb/memdb",
+    "leveldb/opt",
+    "leveldb/storage",
+    "leveldb/table",
+    "leveldb/util",
+  ]
+  pruneopts = "UT"
+  revision = "6b91fda63f2e36186f1c9d0e48578defb69c5d43"
+
+[[projects]]
   digest = "1:3c1a69cdae3501bf75e76d0d86dc6f2b0a7421bc205c0cb7b96b19eed464a34d"
   name = "go.uber.org/atomic"
   packages = ["."]
@@ -249,6 +351,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:7427036b6d926b3d1fa0773771820735b35554a98296f1074df440ee30a97296"
+  name = "golang.org/x/net"
+  packages = ["websocket"]
+  pruneopts = "UT"
+  revision = "04a2e542c03f1d053ab3e4d6e5abcd4b66e2be8e"
+
+[[projects]]
+  branch = "master"
   digest = "1:f5aa274a0377f85735edc7fedfb0811d3cbc20af91633797cb359e29c3272271"
   name = "golang.org/x/sys"
   packages = [
@@ -266,14 +376,30 @@
   revision = "80515d440932108546bcade467bb7d6968e812e2"
   version = "v3.4.0"
 
+[[projects]]
+  branch = "v2"
+  digest = "1:3d3f9391ab615be8655ae0d686a1564f3fec413979bb1aaf018bac1ec1bb1cc7"
+  name = "gopkg.in/natefinch/npipe.v2"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/BurntSushi/toml",
+    "github.com/ethereum/go-ethereum",
+    "github.com/ethereum/go-ethereum/accounts/abi",
+    "github.com/ethereum/go-ethereum/accounts/abi/bind",
+    "github.com/ethereum/go-ethereum/common",
+    "github.com/ethereum/go-ethereum/core/types",
     "github.com/ethereum/go-ethereum/crypto",
+    "github.com/ethereum/go-ethereum/ethclient",
+    "github.com/ethereum/go-ethereum/event",
     "github.com/fatih/color",
     "github.com/gocraft/dbr",
+    "github.com/gocraft/dbr/dialect",
     "github.com/stellar/go/clients/horizon",
     "github.com/stellar/go/keypair",
     "github.com/stellar/go/strkey",

--- a/packages/demo/bridge/README.md
+++ b/packages/demo/bridge/README.md
@@ -12,6 +12,27 @@ To satisfy dependencies and populate the `vendor` directory run:
 $ dep ensure -v
 ```
 
+### Smart Contract ABI generation
+
+We need to install a tool called `abigen` for generating the ABI from a solidity smart contract.
+
+Run the following to install the abigen tool.
+
+```bash
+$ go get -u github.com/ethereum/go-ethereum
+$ cd $GOPATH/src/github.com/ethereum/go-ethereum/
+$ make
+$ make devtools
+```
+
+From the truffle generated build, extract the ABI, the pipe it to `abigen`.
+
+```bash
+$ cat build/contracts/SomeContract.json | jq -r ".abi" | abigen --abi - --pkg contract --out main.go
+```
+
+This will generate a `main.go` file with the package set as `contract`.
+
 ### Issues
 
 There might be an issue with the native golang bindings from go-ethereum and dep, see [here](https://github.com/ethereum/go-ethereum/issues/2738).

--- a/packages/demo/bridge/config/networks.go
+++ b/packages/demo/bridge/config/networks.go
@@ -6,6 +6,8 @@ type networks struct {
 		URL string
 	}
 	Ethereum struct {
-		URL string
+		URL                         string
+		StellarIdentityAccountsAddr string
+		IdentityRegistryAddr        string
 	}
 }

--- a/packages/demo/bridge/services/identity/contract/errors.go
+++ b/packages/demo/bridge/services/identity/contract/errors.go
@@ -1,0 +1,7 @@
+package contract
+
+import "fmt"
+
+var (
+	ErrInitializeContracts = fmt.Errorf("Unable to contracts")
+)

--- a/packages/demo/bridge/services/identity/contract/identityregistry/main.go
+++ b/packages/demo/bridge/services/identity/contract/identityregistry/main.go
@@ -1,0 +1,778 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package identityregistry
+
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = abi.U256
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// IdentityregistryABI is the input ABI used to generate the binding from.
+const IdentityregistryABI = "[{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"networkAccounts\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"ETH_NETWORK\",\"outputs\":[{\"name\":\"\",\"type\":\"uint256\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"\",\"type\":\"address\"}],\"name\":\"identities\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_keyEnums\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"sender\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"identity\",\"type\":\"address\"}],\"name\":\"NewIdentity\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"}],\"name\":\"OwnershipRenounced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"constant\":false,\"inputs\":[],\"name\":\"createIdentity\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"acc\",\"type\":\"address\"}],\"name\":\"setEthereumIdentityAccounts\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"network\",\"type\":\"uint256\"},{\"name\":\"acc\",\"type\":\"address\"}],\"name\":\"setIdentityAccounts\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"network\",\"type\":\"uint256\"}],\"name\":\"removeIdentityAccounts\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// Identityregistry is an auto generated Go binding around an Ethereum contract.
+type Identityregistry struct {
+	IdentityregistryCaller     // Read-only binding to the contract
+	IdentityregistryTransactor // Write-only binding to the contract
+	IdentityregistryFilterer   // Log filterer for contract events
+}
+
+// IdentityregistryCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IdentityregistryCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IdentityregistryTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IdentityregistryTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IdentityregistryFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IdentityregistryFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IdentityregistrySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IdentityregistrySession struct {
+	Contract     *Identityregistry // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IdentityregistryCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IdentityregistryCallerSession struct {
+	Contract *IdentityregistryCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts           // Call options to use throughout this session
+}
+
+// IdentityregistryTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IdentityregistryTransactorSession struct {
+	Contract     *IdentityregistryTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts           // Transaction auth options to use throughout this session
+}
+
+// IdentityregistryRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IdentityregistryRaw struct {
+	Contract *Identityregistry // Generic contract binding to access the raw methods on
+}
+
+// IdentityregistryCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IdentityregistryCallerRaw struct {
+	Contract *IdentityregistryCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IdentityregistryTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IdentityregistryTransactorRaw struct {
+	Contract *IdentityregistryTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIdentityregistry creates a new instance of Identityregistry, bound to a specific deployed contract.
+func NewIdentityregistry(address common.Address, backend bind.ContractBackend) (*Identityregistry, error) {
+	contract, err := bindIdentityregistry(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Identityregistry{IdentityregistryCaller: IdentityregistryCaller{contract: contract}, IdentityregistryTransactor: IdentityregistryTransactor{contract: contract}, IdentityregistryFilterer: IdentityregistryFilterer{contract: contract}}, nil
+}
+
+// NewIdentityregistryCaller creates a new read-only instance of Identityregistry, bound to a specific deployed contract.
+func NewIdentityregistryCaller(address common.Address, caller bind.ContractCaller) (*IdentityregistryCaller, error) {
+	contract, err := bindIdentityregistry(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryCaller{contract: contract}, nil
+}
+
+// NewIdentityregistryTransactor creates a new write-only instance of Identityregistry, bound to a specific deployed contract.
+func NewIdentityregistryTransactor(address common.Address, transactor bind.ContractTransactor) (*IdentityregistryTransactor, error) {
+	contract, err := bindIdentityregistry(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryTransactor{contract: contract}, nil
+}
+
+// NewIdentityregistryFilterer creates a new log filterer instance of Identityregistry, bound to a specific deployed contract.
+func NewIdentityregistryFilterer(address common.Address, filterer bind.ContractFilterer) (*IdentityregistryFilterer, error) {
+	contract, err := bindIdentityregistry(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryFilterer{contract: contract}, nil
+}
+
+// bindIdentityregistry binds a generic wrapper to an already deployed contract.
+func bindIdentityregistry(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(IdentityregistryABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Identityregistry *IdentityregistryRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Identityregistry.Contract.IdentityregistryCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Identityregistry *IdentityregistryRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Identityregistry.Contract.IdentityregistryTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Identityregistry *IdentityregistryRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Identityregistry.Contract.IdentityregistryTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Identityregistry *IdentityregistryCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Identityregistry.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Identityregistry *IdentityregistryTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Identityregistry.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Identityregistry *IdentityregistryTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Identityregistry.Contract.contract.Transact(opts, method, params...)
+}
+
+// ETHNETWORK is a free data retrieval call binding the contract method 0xd1ae75fa.
+//
+// Solidity: function ETH_NETWORK() constant returns(uint256)
+func (_Identityregistry *IdentityregistryCaller) ETHNETWORK(opts *bind.CallOpts) (*big.Int, error) {
+	var (
+		ret0 = new(*big.Int)
+	)
+	out := ret0
+	err := _Identityregistry.contract.Call(opts, out, "ETH_NETWORK")
+	return *ret0, err
+}
+
+// ETHNETWORK is a free data retrieval call binding the contract method 0xd1ae75fa.
+//
+// Solidity: function ETH_NETWORK() constant returns(uint256)
+func (_Identityregistry *IdentityregistrySession) ETHNETWORK() (*big.Int, error) {
+	return _Identityregistry.Contract.ETHNETWORK(&_Identityregistry.CallOpts)
+}
+
+// ETHNETWORK is a free data retrieval call binding the contract method 0xd1ae75fa.
+//
+// Solidity: function ETH_NETWORK() constant returns(uint256)
+func (_Identityregistry *IdentityregistryCallerSession) ETHNETWORK() (*big.Int, error) {
+	return _Identityregistry.Contract.ETHNETWORK(&_Identityregistry.CallOpts)
+}
+
+// Identities is a free data retrieval call binding the contract method 0xf653b81e.
+//
+// Solidity: function identities( address) constant returns(bool)
+func (_Identityregistry *IdentityregistryCaller) Identities(opts *bind.CallOpts, arg0 common.Address) (bool, error) {
+	var (
+		ret0 = new(bool)
+	)
+	out := ret0
+	err := _Identityregistry.contract.Call(opts, out, "identities", arg0)
+	return *ret0, err
+}
+
+// Identities is a free data retrieval call binding the contract method 0xf653b81e.
+//
+// Solidity: function identities( address) constant returns(bool)
+func (_Identityregistry *IdentityregistrySession) Identities(arg0 common.Address) (bool, error) {
+	return _Identityregistry.Contract.Identities(&_Identityregistry.CallOpts, arg0)
+}
+
+// Identities is a free data retrieval call binding the contract method 0xf653b81e.
+//
+// Solidity: function identities( address) constant returns(bool)
+func (_Identityregistry *IdentityregistryCallerSession) Identities(arg0 common.Address) (bool, error) {
+	return _Identityregistry.Contract.Identities(&_Identityregistry.CallOpts, arg0)
+}
+
+// NetworkAccounts is a free data retrieval call binding the contract method 0xb8566785.
+//
+// Solidity: function networkAccounts( uint256) constant returns(address)
+func (_Identityregistry *IdentityregistryCaller) NetworkAccounts(opts *bind.CallOpts, arg0 *big.Int) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Identityregistry.contract.Call(opts, out, "networkAccounts", arg0)
+	return *ret0, err
+}
+
+// NetworkAccounts is a free data retrieval call binding the contract method 0xb8566785.
+//
+// Solidity: function networkAccounts( uint256) constant returns(address)
+func (_Identityregistry *IdentityregistrySession) NetworkAccounts(arg0 *big.Int) (common.Address, error) {
+	return _Identityregistry.Contract.NetworkAccounts(&_Identityregistry.CallOpts, arg0)
+}
+
+// NetworkAccounts is a free data retrieval call binding the contract method 0xb8566785.
+//
+// Solidity: function networkAccounts( uint256) constant returns(address)
+func (_Identityregistry *IdentityregistryCallerSession) NetworkAccounts(arg0 *big.Int) (common.Address, error) {
+	return _Identityregistry.Contract.NetworkAccounts(&_Identityregistry.CallOpts, arg0)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Identityregistry *IdentityregistryCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Identityregistry.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Identityregistry *IdentityregistrySession) Owner() (common.Address, error) {
+	return _Identityregistry.Contract.Owner(&_Identityregistry.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Identityregistry *IdentityregistryCallerSession) Owner() (common.Address, error) {
+	return _Identityregistry.Contract.Owner(&_Identityregistry.CallOpts)
+}
+
+// CreateIdentity is a paid mutator transaction binding the contract method 0x59d21ad9.
+//
+// Solidity: function createIdentity() returns(address)
+func (_Identityregistry *IdentityregistryTransactor) CreateIdentity(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Identityregistry.contract.Transact(opts, "createIdentity")
+}
+
+// CreateIdentity is a paid mutator transaction binding the contract method 0x59d21ad9.
+//
+// Solidity: function createIdentity() returns(address)
+func (_Identityregistry *IdentityregistrySession) CreateIdentity() (*types.Transaction, error) {
+	return _Identityregistry.Contract.CreateIdentity(&_Identityregistry.TransactOpts)
+}
+
+// CreateIdentity is a paid mutator transaction binding the contract method 0x59d21ad9.
+//
+// Solidity: function createIdentity() returns(address)
+func (_Identityregistry *IdentityregistryTransactorSession) CreateIdentity() (*types.Transaction, error) {
+	return _Identityregistry.Contract.CreateIdentity(&_Identityregistry.TransactOpts)
+}
+
+// RemoveIdentityAccounts is a paid mutator transaction binding the contract method 0x2a437ac7.
+//
+// Solidity: function removeIdentityAccounts(network uint256) returns()
+func (_Identityregistry *IdentityregistryTransactor) RemoveIdentityAccounts(opts *bind.TransactOpts, network *big.Int) (*types.Transaction, error) {
+	return _Identityregistry.contract.Transact(opts, "removeIdentityAccounts", network)
+}
+
+// RemoveIdentityAccounts is a paid mutator transaction binding the contract method 0x2a437ac7.
+//
+// Solidity: function removeIdentityAccounts(network uint256) returns()
+func (_Identityregistry *IdentityregistrySession) RemoveIdentityAccounts(network *big.Int) (*types.Transaction, error) {
+	return _Identityregistry.Contract.RemoveIdentityAccounts(&_Identityregistry.TransactOpts, network)
+}
+
+// RemoveIdentityAccounts is a paid mutator transaction binding the contract method 0x2a437ac7.
+//
+// Solidity: function removeIdentityAccounts(network uint256) returns()
+func (_Identityregistry *IdentityregistryTransactorSession) RemoveIdentityAccounts(network *big.Int) (*types.Transaction, error) {
+	return _Identityregistry.Contract.RemoveIdentityAccounts(&_Identityregistry.TransactOpts, network)
+}
+
+// SetEthereumIdentityAccounts is a paid mutator transaction binding the contract method 0x36ee830d.
+//
+// Solidity: function setEthereumIdentityAccounts(acc address) returns()
+func (_Identityregistry *IdentityregistryTransactor) SetEthereumIdentityAccounts(opts *bind.TransactOpts, acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.contract.Transact(opts, "setEthereumIdentityAccounts", acc)
+}
+
+// SetEthereumIdentityAccounts is a paid mutator transaction binding the contract method 0x36ee830d.
+//
+// Solidity: function setEthereumIdentityAccounts(acc address) returns()
+func (_Identityregistry *IdentityregistrySession) SetEthereumIdentityAccounts(acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.SetEthereumIdentityAccounts(&_Identityregistry.TransactOpts, acc)
+}
+
+// SetEthereumIdentityAccounts is a paid mutator transaction binding the contract method 0x36ee830d.
+//
+// Solidity: function setEthereumIdentityAccounts(acc address) returns()
+func (_Identityregistry *IdentityregistryTransactorSession) SetEthereumIdentityAccounts(acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.SetEthereumIdentityAccounts(&_Identityregistry.TransactOpts, acc)
+}
+
+// SetIdentityAccounts is a paid mutator transaction binding the contract method 0xc83296a8.
+//
+// Solidity: function setIdentityAccounts(network uint256, acc address) returns()
+func (_Identityregistry *IdentityregistryTransactor) SetIdentityAccounts(opts *bind.TransactOpts, network *big.Int, acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.contract.Transact(opts, "setIdentityAccounts", network, acc)
+}
+
+// SetIdentityAccounts is a paid mutator transaction binding the contract method 0xc83296a8.
+//
+// Solidity: function setIdentityAccounts(network uint256, acc address) returns()
+func (_Identityregistry *IdentityregistrySession) SetIdentityAccounts(network *big.Int, acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.SetIdentityAccounts(&_Identityregistry.TransactOpts, network, acc)
+}
+
+// SetIdentityAccounts is a paid mutator transaction binding the contract method 0xc83296a8.
+//
+// Solidity: function setIdentityAccounts(network uint256, acc address) returns()
+func (_Identityregistry *IdentityregistryTransactorSession) SetIdentityAccounts(network *big.Int, acc common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.SetIdentityAccounts(&_Identityregistry.TransactOpts, network, acc)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Identityregistry *IdentityregistryTransactor) TransferOwnership(opts *bind.TransactOpts, _newOwner common.Address) (*types.Transaction, error) {
+	return _Identityregistry.contract.Transact(opts, "transferOwnership", _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Identityregistry *IdentityregistrySession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.TransferOwnership(&_Identityregistry.TransactOpts, _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Identityregistry *IdentityregistryTransactorSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Identityregistry.Contract.TransferOwnership(&_Identityregistry.TransactOpts, _newOwner)
+}
+
+// IdentityregistryNewIdentityIterator is returned from FilterNewIdentity and is used to iterate over the raw logs and unpacked data for NewIdentity events raised by the Identityregistry contract.
+type IdentityregistryNewIdentityIterator struct {
+	Event *IdentityregistryNewIdentity // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IdentityregistryNewIdentityIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IdentityregistryNewIdentity)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IdentityregistryNewIdentity)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IdentityregistryNewIdentityIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IdentityregistryNewIdentityIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IdentityregistryNewIdentity represents a NewIdentity event raised by the Identityregistry contract.
+type IdentityregistryNewIdentity struct {
+	Sender   common.Address
+	Identity common.Address
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterNewIdentity is a free log retrieval operation binding the contract event 0x4bbb10c11c6c8c35689f097fa303b69ba45da8472d34886663ebbf3b1a42ce28.
+//
+// Solidity: e NewIdentity(sender address, identity address)
+func (_Identityregistry *IdentityregistryFilterer) FilterNewIdentity(opts *bind.FilterOpts) (*IdentityregistryNewIdentityIterator, error) {
+
+	logs, sub, err := _Identityregistry.contract.FilterLogs(opts, "NewIdentity")
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryNewIdentityIterator{contract: _Identityregistry.contract, event: "NewIdentity", logs: logs, sub: sub}, nil
+}
+
+// WatchNewIdentity is a free log subscription operation binding the contract event 0x4bbb10c11c6c8c35689f097fa303b69ba45da8472d34886663ebbf3b1a42ce28.
+//
+// Solidity: e NewIdentity(sender address, identity address)
+func (_Identityregistry *IdentityregistryFilterer) WatchNewIdentity(opts *bind.WatchOpts, sink chan<- *IdentityregistryNewIdentity) (event.Subscription, error) {
+
+	logs, sub, err := _Identityregistry.contract.WatchLogs(opts, "NewIdentity")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IdentityregistryNewIdentity)
+				if err := _Identityregistry.contract.UnpackLog(event, "NewIdentity", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// IdentityregistryOwnershipRenouncedIterator is returned from FilterOwnershipRenounced and is used to iterate over the raw logs and unpacked data for OwnershipRenounced events raised by the Identityregistry contract.
+type IdentityregistryOwnershipRenouncedIterator struct {
+	Event *IdentityregistryOwnershipRenounced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IdentityregistryOwnershipRenouncedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IdentityregistryOwnershipRenounced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IdentityregistryOwnershipRenounced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IdentityregistryOwnershipRenouncedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IdentityregistryOwnershipRenouncedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IdentityregistryOwnershipRenounced represents a OwnershipRenounced event raised by the Identityregistry contract.
+type IdentityregistryOwnershipRenounced struct {
+	PreviousOwner common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipRenounced is a free log retrieval operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Identityregistry *IdentityregistryFilterer) FilterOwnershipRenounced(opts *bind.FilterOpts, previousOwner []common.Address) (*IdentityregistryOwnershipRenouncedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Identityregistry.contract.FilterLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryOwnershipRenouncedIterator{contract: _Identityregistry.contract, event: "OwnershipRenounced", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipRenounced is a free log subscription operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Identityregistry *IdentityregistryFilterer) WatchOwnershipRenounced(opts *bind.WatchOpts, sink chan<- *IdentityregistryOwnershipRenounced, previousOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Identityregistry.contract.WatchLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IdentityregistryOwnershipRenounced)
+				if err := _Identityregistry.contract.UnpackLog(event, "OwnershipRenounced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// IdentityregistryOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Identityregistry contract.
+type IdentityregistryOwnershipTransferredIterator struct {
+	Event *IdentityregistryOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IdentityregistryOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IdentityregistryOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IdentityregistryOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IdentityregistryOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IdentityregistryOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IdentityregistryOwnershipTransferred represents a OwnershipTransferred event raised by the Identityregistry contract.
+type IdentityregistryOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Identityregistry *IdentityregistryFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*IdentityregistryOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Identityregistry.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityregistryOwnershipTransferredIterator{contract: _Identityregistry.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Identityregistry *IdentityregistryFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *IdentityregistryOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Identityregistry.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IdentityregistryOwnershipTransferred)
+				if err := _Identityregistry.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}

--- a/packages/demo/bridge/services/identity/contract/main.go
+++ b/packages/demo/bridge/services/identity/contract/main.go
@@ -1,0 +1,52 @@
+package contract
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/identityregistry"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/stellaridentityaccounts"
+	"go.uber.org/zap"
+)
+
+type Contracts struct {
+	IdentityRegistry        *identityregistry.Identityregistry
+	IdentityRegistryAddress common.Address
+
+	StellarIdentityAccounts        *stellaridentityaccounts.Stellaridentityaccounts
+	StellarIdentityAccountsAddress common.Address
+}
+
+func NewContracts(
+	logger *zap.Logger,
+	ethereumClient *ethclient.Client,
+	identityRegistryAddrStr string,
+	stellarIdentityAccountsAddrStr string,
+) (*Contracts, error) {
+
+	identityRegistryAddr := common.HexToAddress(identityRegistryAddrStr)
+	identityRegistryContract, err := identityregistry.NewIdentityregistry(identityRegistryAddr, ethereumClient)
+	if err != nil {
+		logger.Error("Unable to instantiate stellar identity contract",
+			zap.Error(err),
+			zap.String("Address", identityRegistryAddr.Hex()),
+		)
+		return nil, ErrInitializeContracts
+	}
+
+	stellarIdentityAccountsAddr := common.HexToAddress(stellarIdentityAccountsAddrStr)
+	stellarIdentityAccountsContract, err := stellaridentityaccounts.NewStellaridentityaccounts(stellarIdentityAccountsAddr, ethereumClient)
+	if err != nil {
+		logger.Fatal("Unable to instantiate stellar identity contract",
+			zap.Error(err),
+			zap.String("Address", stellarIdentityAccountsAddr.Hex()),
+		)
+		return nil, ErrInitializeContracts
+	}
+
+	return &Contracts{
+		IdentityRegistry:               identityRegistryContract,
+		IdentityRegistryAddress:        identityRegistryAddr,
+		StellarIdentityAccounts:        stellarIdentityAccountsContract,
+		StellarIdentityAccountsAddress: stellarIdentityAccountsAddr,
+	}, nil
+}

--- a/packages/demo/bridge/services/identity/contract/stellaridentityaccounts/account_events.go
+++ b/packages/demo/bridge/services/identity/contract/stellaridentityaccounts/account_events.go
@@ -1,0 +1,69 @@
+package stellaridentityaccounts
+
+import (
+	"encoding/hex"
+
+	"github.com/stellar/go/strkey"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"go.uber.org/zap/zapcore"
+)
+
+type AccountEvent struct {
+	Name        string
+	Identity    common.Address
+	Account     [32]byte
+	Raw         types.Log // Blockchain specific contextual infos
+	BlockHeader *types.Header
+}
+
+type AccountEventSlice []AccountEvent
+
+func (e *AccountEvent) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("Block", e.Raw.BlockNumber)
+	enc.AddString("TxHash", e.Raw.TxHash.Hex())
+	enc.AddString("Name", e.Name)
+	enc.AddString("Identity Address", e.Identity.Hex())
+	enc.AddString("Account Address", hex.EncodeToString(e.Account[:]))
+	if encoded, err := strkey.Encode(strkey.VersionByteAccountID, e.Account[:]); err == nil {
+		enc.AddString("Encoded Account Address", encoded)
+	}
+	return nil
+}
+
+func (s AccountEventSlice) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	for _, e := range s {
+		if err := enc.AppendObject(&e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *StellaridentityaccountsAccountRequested) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("Block", e.Raw.BlockNumber)
+	enc.AddString("TxHash", e.Raw.TxHash.Hex())
+	enc.AddString("Identity Address", e.Identity.Hex())
+	enc.AddString("Account Address", hex.EncodeToString(e.Account[:]))
+
+	return nil
+}
+
+func (e *StellaridentityaccountsAccountAdded) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("Block", e.Raw.BlockNumber)
+	enc.AddString("TxHash", e.Raw.TxHash.Hex())
+	enc.AddString("Identity Address", e.Identity.Hex())
+	enc.AddString("Account Address", hex.EncodeToString(e.Account[:]))
+
+	return nil
+}
+
+func (e *StellaridentityaccountsAccountRemoved) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("Block", e.Raw.BlockNumber)
+	enc.AddString("TxHash", e.Raw.TxHash.Hex())
+	enc.AddString("Identity Address", e.Identity.Hex())
+	enc.AddString("Account Address", hex.EncodeToString(e.Account[:]))
+
+	return nil
+}

--- a/packages/demo/bridge/services/identity/contract/stellaridentityaccounts/main.go
+++ b/packages/demo/bridge/services/identity/contract/stellaridentityaccounts/main.go
@@ -1,0 +1,1003 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package stellaridentityaccounts
+
+import (
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = abi.U256
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+// StellaridentityaccountsABI is the input ABI used to generate the binding from.
+const StellaridentityaccountsABI = "[{\"constant\":true,\"inputs\":[],\"name\":\"registry\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"_newOwner\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"name\":\"_registry\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"identity\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"AccountRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"identity\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"AccountAdded\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"name\":\"identity\",\"type\":\"address\"},{\"indexed\":false,\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"AccountRemoved\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"}],\"name\":\"OwnershipRenounced\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"name\":\"previousOwner\",\"type\":\"address\"},{\"indexed\":true,\"name\":\"newOwner\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"constant\":true,\"inputs\":[{\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"getIdentity\",\"outputs\":[{\"name\":\"\",\"type\":\"address\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":true,\"inputs\":[{\"name\":\"identity\",\"type\":\"address\"}],\"name\":\"getAccounts\",\"outputs\":[{\"name\":\"\",\"type\":\"bytes32[]\"}],\"payable\":false,\"stateMutability\":\"view\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"identity\",\"type\":\"address\"},{\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"addAccount\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"identity\",\"type\":\"address\"},{\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"approve\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"constant\":false,\"inputs\":[{\"name\":\"identity\",\"type\":\"address\"},{\"name\":\"account\",\"type\":\"bytes32\"}],\"name\":\"removeAccount\",\"outputs\":[{\"name\":\"\",\"type\":\"bool\"}],\"payable\":false,\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+
+// Stellaridentityaccounts is an auto generated Go binding around an Ethereum contract.
+type Stellaridentityaccounts struct {
+	StellaridentityaccountsCaller     // Read-only binding to the contract
+	StellaridentityaccountsTransactor // Write-only binding to the contract
+	StellaridentityaccountsFilterer   // Log filterer for contract events
+}
+
+// StellaridentityaccountsCaller is an auto generated read-only Go binding around an Ethereum contract.
+type StellaridentityaccountsCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StellaridentityaccountsTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type StellaridentityaccountsTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StellaridentityaccountsFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type StellaridentityaccountsFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// StellaridentityaccountsSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type StellaridentityaccountsSession struct {
+	Contract     *Stellaridentityaccounts // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts            // Call options to use throughout this session
+	TransactOpts bind.TransactOpts        // Transaction auth options to use throughout this session
+}
+
+// StellaridentityaccountsCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type StellaridentityaccountsCallerSession struct {
+	Contract *StellaridentityaccountsCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts                  // Call options to use throughout this session
+}
+
+// StellaridentityaccountsTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type StellaridentityaccountsTransactorSession struct {
+	Contract     *StellaridentityaccountsTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts                  // Transaction auth options to use throughout this session
+}
+
+// StellaridentityaccountsRaw is an auto generated low-level Go binding around an Ethereum contract.
+type StellaridentityaccountsRaw struct {
+	Contract *Stellaridentityaccounts // Generic contract binding to access the raw methods on
+}
+
+// StellaridentityaccountsCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type StellaridentityaccountsCallerRaw struct {
+	Contract *StellaridentityaccountsCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// StellaridentityaccountsTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type StellaridentityaccountsTransactorRaw struct {
+	Contract *StellaridentityaccountsTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewStellaridentityaccounts creates a new instance of Stellaridentityaccounts, bound to a specific deployed contract.
+func NewStellaridentityaccounts(address common.Address, backend bind.ContractBackend) (*Stellaridentityaccounts, error) {
+	contract, err := bindStellaridentityaccounts(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Stellaridentityaccounts{StellaridentityaccountsCaller: StellaridentityaccountsCaller{contract: contract}, StellaridentityaccountsTransactor: StellaridentityaccountsTransactor{contract: contract}, StellaridentityaccountsFilterer: StellaridentityaccountsFilterer{contract: contract}}, nil
+}
+
+// NewStellaridentityaccountsCaller creates a new read-only instance of Stellaridentityaccounts, bound to a specific deployed contract.
+func NewStellaridentityaccountsCaller(address common.Address, caller bind.ContractCaller) (*StellaridentityaccountsCaller, error) {
+	contract, err := bindStellaridentityaccounts(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsCaller{contract: contract}, nil
+}
+
+// NewStellaridentityaccountsTransactor creates a new write-only instance of Stellaridentityaccounts, bound to a specific deployed contract.
+func NewStellaridentityaccountsTransactor(address common.Address, transactor bind.ContractTransactor) (*StellaridentityaccountsTransactor, error) {
+	contract, err := bindStellaridentityaccounts(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsTransactor{contract: contract}, nil
+}
+
+// NewStellaridentityaccountsFilterer creates a new log filterer instance of Stellaridentityaccounts, bound to a specific deployed contract.
+func NewStellaridentityaccountsFilterer(address common.Address, filterer bind.ContractFilterer) (*StellaridentityaccountsFilterer, error) {
+	contract, err := bindStellaridentityaccounts(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsFilterer{contract: contract}, nil
+}
+
+// bindStellaridentityaccounts binds a generic wrapper to an already deployed contract.
+func bindStellaridentityaccounts(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(StellaridentityaccountsABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Stellaridentityaccounts *StellaridentityaccountsRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Stellaridentityaccounts.Contract.StellaridentityaccountsCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Stellaridentityaccounts *StellaridentityaccountsRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.StellaridentityaccountsTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Stellaridentityaccounts *StellaridentityaccountsRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.StellaridentityaccountsTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Stellaridentityaccounts *StellaridentityaccountsCallerRaw) Call(opts *bind.CallOpts, result interface{}, method string, params ...interface{}) error {
+	return _Stellaridentityaccounts.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetAccounts is a free data retrieval call binding the contract method 0x3100ceb5.
+//
+// Solidity: function getAccounts(identity address) constant returns(bytes32[])
+func (_Stellaridentityaccounts *StellaridentityaccountsCaller) GetAccounts(opts *bind.CallOpts, identity common.Address) ([][32]byte, error) {
+	var (
+		ret0 = new([][32]byte)
+	)
+	out := ret0
+	err := _Stellaridentityaccounts.contract.Call(opts, out, "getAccounts", identity)
+	return *ret0, err
+}
+
+// GetAccounts is a free data retrieval call binding the contract method 0x3100ceb5.
+//
+// Solidity: function getAccounts(identity address) constant returns(bytes32[])
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) GetAccounts(identity common.Address) ([][32]byte, error) {
+	return _Stellaridentityaccounts.Contract.GetAccounts(&_Stellaridentityaccounts.CallOpts, identity)
+}
+
+// GetAccounts is a free data retrieval call binding the contract method 0x3100ceb5.
+//
+// Solidity: function getAccounts(identity address) constant returns(bytes32[])
+func (_Stellaridentityaccounts *StellaridentityaccountsCallerSession) GetAccounts(identity common.Address) ([][32]byte, error) {
+	return _Stellaridentityaccounts.Contract.GetAccounts(&_Stellaridentityaccounts.CallOpts, identity)
+}
+
+// GetIdentity is a free data retrieval call binding the contract method 0xa7867212.
+//
+// Solidity: function getIdentity(account bytes32) constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCaller) GetIdentity(opts *bind.CallOpts, account [32]byte) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Stellaridentityaccounts.contract.Call(opts, out, "getIdentity", account)
+	return *ret0, err
+}
+
+// GetIdentity is a free data retrieval call binding the contract method 0xa7867212.
+//
+// Solidity: function getIdentity(account bytes32) constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) GetIdentity(account [32]byte) (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.GetIdentity(&_Stellaridentityaccounts.CallOpts, account)
+}
+
+// GetIdentity is a free data retrieval call binding the contract method 0xa7867212.
+//
+// Solidity: function getIdentity(account bytes32) constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCallerSession) GetIdentity(account [32]byte) (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.GetIdentity(&_Stellaridentityaccounts.CallOpts, account)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Stellaridentityaccounts.contract.Call(opts, out, "owner")
+	return *ret0, err
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) Owner() (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.Owner(&_Stellaridentityaccounts.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCallerSession) Owner() (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.Owner(&_Stellaridentityaccounts.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCaller) Registry(opts *bind.CallOpts) (common.Address, error) {
+	var (
+		ret0 = new(common.Address)
+	)
+	out := ret0
+	err := _Stellaridentityaccounts.contract.Call(opts, out, "registry")
+	return *ret0, err
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) Registry() (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.Registry(&_Stellaridentityaccounts.CallOpts)
+}
+
+// Registry is a free data retrieval call binding the contract method 0x7b103999.
+//
+// Solidity: function registry() constant returns(address)
+func (_Stellaridentityaccounts *StellaridentityaccountsCallerSession) Registry() (common.Address, error) {
+	return _Stellaridentityaccounts.Contract.Registry(&_Stellaridentityaccounts.CallOpts)
+}
+
+// AddAccount is a paid mutator transaction binding the contract method 0x5d8b7bb3.
+//
+// Solidity: function addAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactor) AddAccount(opts *bind.TransactOpts, identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.contract.Transact(opts, "addAccount", identity, account)
+}
+
+// AddAccount is a paid mutator transaction binding the contract method 0x5d8b7bb3.
+//
+// Solidity: function addAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) AddAccount(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.AddAccount(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// AddAccount is a paid mutator transaction binding the contract method 0x5d8b7bb3.
+//
+// Solidity: function addAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorSession) AddAccount(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.AddAccount(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x5cd2f4d3.
+//
+// Solidity: function approve(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactor) Approve(opts *bind.TransactOpts, identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.contract.Transact(opts, "approve", identity, account)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x5cd2f4d3.
+//
+// Solidity: function approve(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) Approve(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.Approve(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// Approve is a paid mutator transaction binding the contract method 0x5cd2f4d3.
+//
+// Solidity: function approve(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorSession) Approve(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.Approve(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// RemoveAccount is a paid mutator transaction binding the contract method 0xc039f242.
+//
+// Solidity: function removeAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactor) RemoveAccount(opts *bind.TransactOpts, identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.contract.Transact(opts, "removeAccount", identity, account)
+}
+
+// RemoveAccount is a paid mutator transaction binding the contract method 0xc039f242.
+//
+// Solidity: function removeAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) RemoveAccount(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.RemoveAccount(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// RemoveAccount is a paid mutator transaction binding the contract method 0xc039f242.
+//
+// Solidity: function removeAccount(identity address, account bytes32) returns(bool)
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorSession) RemoveAccount(identity common.Address, account [32]byte) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.RemoveAccount(&_Stellaridentityaccounts.TransactOpts, identity, account)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactor) TransferOwnership(opts *bind.TransactOpts, _newOwner common.Address) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.contract.Transact(opts, "transferOwnership", _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Stellaridentityaccounts *StellaridentityaccountsSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.TransferOwnership(&_Stellaridentityaccounts.TransactOpts, _newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(_newOwner address) returns()
+func (_Stellaridentityaccounts *StellaridentityaccountsTransactorSession) TransferOwnership(_newOwner common.Address) (*types.Transaction, error) {
+	return _Stellaridentityaccounts.Contract.TransferOwnership(&_Stellaridentityaccounts.TransactOpts, _newOwner)
+}
+
+// StellaridentityaccountsAccountAddedIterator is returned from FilterAccountAdded and is used to iterate over the raw logs and unpacked data for AccountAdded events raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountAddedIterator struct {
+	Event *StellaridentityaccountsAccountAdded // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StellaridentityaccountsAccountAddedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StellaridentityaccountsAccountAdded)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StellaridentityaccountsAccountAdded)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StellaridentityaccountsAccountAddedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StellaridentityaccountsAccountAddedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StellaridentityaccountsAccountAdded represents a AccountAdded event raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountAdded struct {
+	Identity common.Address
+	Account  [32]byte
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterAccountAdded is a free log retrieval operation binding the contract event 0x09163f55dc2f2008a65785b2c4ef132aab22d6825e437d115ce002d126682e32.
+//
+// Solidity: e AccountAdded(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) FilterAccountAdded(opts *bind.FilterOpts) (*StellaridentityaccountsAccountAddedIterator, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.FilterLogs(opts, "AccountAdded")
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsAccountAddedIterator{contract: _Stellaridentityaccounts.contract, event: "AccountAdded", logs: logs, sub: sub}, nil
+}
+
+// WatchAccountAdded is a free log subscription operation binding the contract event 0x09163f55dc2f2008a65785b2c4ef132aab22d6825e437d115ce002d126682e32.
+//
+// Solidity: e AccountAdded(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) WatchAccountAdded(opts *bind.WatchOpts, sink chan<- *StellaridentityaccountsAccountAdded) (event.Subscription, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.WatchLogs(opts, "AccountAdded")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StellaridentityaccountsAccountAdded)
+				if err := _Stellaridentityaccounts.contract.UnpackLog(event, "AccountAdded", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// StellaridentityaccountsAccountRemovedIterator is returned from FilterAccountRemoved and is used to iterate over the raw logs and unpacked data for AccountRemoved events raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountRemovedIterator struct {
+	Event *StellaridentityaccountsAccountRemoved // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StellaridentityaccountsAccountRemovedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StellaridentityaccountsAccountRemoved)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StellaridentityaccountsAccountRemoved)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StellaridentityaccountsAccountRemovedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StellaridentityaccountsAccountRemovedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StellaridentityaccountsAccountRemoved represents a AccountRemoved event raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountRemoved struct {
+	Identity common.Address
+	Account  [32]byte
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterAccountRemoved is a free log retrieval operation binding the contract event 0x8a01c8fb015f11879628fd01fad3e27c061f05e281d56c62fa6e251be294b72f.
+//
+// Solidity: e AccountRemoved(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) FilterAccountRemoved(opts *bind.FilterOpts) (*StellaridentityaccountsAccountRemovedIterator, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.FilterLogs(opts, "AccountRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsAccountRemovedIterator{contract: _Stellaridentityaccounts.contract, event: "AccountRemoved", logs: logs, sub: sub}, nil
+}
+
+// WatchAccountRemoved is a free log subscription operation binding the contract event 0x8a01c8fb015f11879628fd01fad3e27c061f05e281d56c62fa6e251be294b72f.
+//
+// Solidity: e AccountRemoved(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) WatchAccountRemoved(opts *bind.WatchOpts, sink chan<- *StellaridentityaccountsAccountRemoved) (event.Subscription, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.WatchLogs(opts, "AccountRemoved")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StellaridentityaccountsAccountRemoved)
+				if err := _Stellaridentityaccounts.contract.UnpackLog(event, "AccountRemoved", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// StellaridentityaccountsAccountRequestedIterator is returned from FilterAccountRequested and is used to iterate over the raw logs and unpacked data for AccountRequested events raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountRequestedIterator struct {
+	Event *StellaridentityaccountsAccountRequested // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StellaridentityaccountsAccountRequestedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StellaridentityaccountsAccountRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StellaridentityaccountsAccountRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StellaridentityaccountsAccountRequestedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StellaridentityaccountsAccountRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StellaridentityaccountsAccountRequested represents a AccountRequested event raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsAccountRequested struct {
+	Identity common.Address
+	Account  [32]byte
+	Raw      types.Log // Blockchain specific contextual infos
+}
+
+// FilterAccountRequested is a free log retrieval operation binding the contract event 0x7330128996a8e25ee5850873f28dbeed6551030d2c577f9210d6764c4b1da4fe.
+//
+// Solidity: e AccountRequested(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) FilterAccountRequested(opts *bind.FilterOpts) (*StellaridentityaccountsAccountRequestedIterator, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.FilterLogs(opts, "AccountRequested")
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsAccountRequestedIterator{contract: _Stellaridentityaccounts.contract, event: "AccountRequested", logs: logs, sub: sub}, nil
+}
+
+// WatchAccountRequested is a free log subscription operation binding the contract event 0x7330128996a8e25ee5850873f28dbeed6551030d2c577f9210d6764c4b1da4fe.
+//
+// Solidity: e AccountRequested(identity address, account bytes32)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) WatchAccountRequested(opts *bind.WatchOpts, sink chan<- *StellaridentityaccountsAccountRequested) (event.Subscription, error) {
+
+	logs, sub, err := _Stellaridentityaccounts.contract.WatchLogs(opts, "AccountRequested")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StellaridentityaccountsAccountRequested)
+				if err := _Stellaridentityaccounts.contract.UnpackLog(event, "AccountRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// StellaridentityaccountsOwnershipRenouncedIterator is returned from FilterOwnershipRenounced and is used to iterate over the raw logs and unpacked data for OwnershipRenounced events raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsOwnershipRenouncedIterator struct {
+	Event *StellaridentityaccountsOwnershipRenounced // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StellaridentityaccountsOwnershipRenouncedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StellaridentityaccountsOwnershipRenounced)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StellaridentityaccountsOwnershipRenounced)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StellaridentityaccountsOwnershipRenouncedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StellaridentityaccountsOwnershipRenouncedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StellaridentityaccountsOwnershipRenounced represents a OwnershipRenounced event raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsOwnershipRenounced struct {
+	PreviousOwner common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipRenounced is a free log retrieval operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) FilterOwnershipRenounced(opts *bind.FilterOpts, previousOwner []common.Address) (*StellaridentityaccountsOwnershipRenouncedIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Stellaridentityaccounts.contract.FilterLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsOwnershipRenouncedIterator{contract: _Stellaridentityaccounts.contract, event: "OwnershipRenounced", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipRenounced is a free log subscription operation binding the contract event 0xf8df31144d9c2f0f6b59d69b8b98abd5459d07f2742c4df920b25aae33c64820.
+//
+// Solidity: e OwnershipRenounced(previousOwner indexed address)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) WatchOwnershipRenounced(opts *bind.WatchOpts, sink chan<- *StellaridentityaccountsOwnershipRenounced, previousOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+
+	logs, sub, err := _Stellaridentityaccounts.contract.WatchLogs(opts, "OwnershipRenounced", previousOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StellaridentityaccountsOwnershipRenounced)
+				if err := _Stellaridentityaccounts.contract.UnpackLog(event, "OwnershipRenounced", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// StellaridentityaccountsOwnershipTransferredIterator is returned from FilterOwnershipTransferred and is used to iterate over the raw logs and unpacked data for OwnershipTransferred events raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsOwnershipTransferredIterator struct {
+	Event *StellaridentityaccountsOwnershipTransferred // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *StellaridentityaccountsOwnershipTransferredIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(StellaridentityaccountsOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(StellaridentityaccountsOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *StellaridentityaccountsOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *StellaridentityaccountsOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// StellaridentityaccountsOwnershipTransferred represents a OwnershipTransferred event raised by the Stellaridentityaccounts contract.
+type StellaridentityaccountsOwnershipTransferred struct {
+	PreviousOwner common.Address
+	NewOwner      common.Address
+	Raw           types.Log // Blockchain specific contextual infos
+}
+
+// FilterOwnershipTransferred is a free log retrieval operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, previousOwner []common.Address, newOwner []common.Address) (*StellaridentityaccountsOwnershipTransferredIterator, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Stellaridentityaccounts.contract.FilterLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &StellaridentityaccountsOwnershipTransferredIterator{contract: _Stellaridentityaccounts.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+// WatchOwnershipTransferred is a free log subscription operation binding the contract event 0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0.
+//
+// Solidity: e OwnershipTransferred(previousOwner indexed address, newOwner indexed address)
+func (_Stellaridentityaccounts *StellaridentityaccountsFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *StellaridentityaccountsOwnershipTransferred, previousOwner []common.Address, newOwner []common.Address) (event.Subscription, error) {
+
+	var previousOwnerRule []interface{}
+	for _, previousOwnerItem := range previousOwner {
+		previousOwnerRule = append(previousOwnerRule, previousOwnerItem)
+	}
+	var newOwnerRule []interface{}
+	for _, newOwnerItem := range newOwner {
+		newOwnerRule = append(newOwnerRule, newOwnerItem)
+	}
+
+	logs, sub, err := _Stellaridentityaccounts.contract.WatchLogs(opts, "OwnershipTransferred", previousOwnerRule, newOwnerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(StellaridentityaccountsOwnershipTransferred)
+				if err := _Stellaridentityaccounts.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}

--- a/packages/demo/bridge/services/identity/db/internal.go
+++ b/packages/demo/bridge/services/identity/db/internal.go
@@ -35,6 +35,8 @@ const (
 
 	columnReceivedPaymentID = "received_payment_id"
 	columnEthereumAddress   = "ethereum_address"
+	columnSenderAddress     = "sender_address"
+	columnNonce             = "nonce"
 )
 
 // pgTimeFormat is RFC3339 which has timezone information and accepted by pg

--- a/packages/demo/bridge/services/identity/db/internal.go
+++ b/packages/demo/bridge/services/identity/db/internal.go
@@ -9,9 +9,11 @@ import (
 
 // Tables
 const (
-	tableStellarAccounts  = "stellar_accounts"
-	tableReceivedPayments = "stellar_received_payments"
-	tableLinkRequests     = "link_requests"
+	tableStellarAccounts               = "stellar_accounts"
+	tableReceivedPayments              = "stellar_received_payments"
+	tableLinkRequests                  = "link_requests"
+	tableContracts                     = "contracts"
+	tableStellarIdentityAccountsEvents = "stellar_identity_accounts_events"
 )
 
 // Columns
@@ -37,6 +39,15 @@ const (
 	columnEthereumAddress   = "ethereum_address"
 	columnSenderAddress     = "sender_address"
 	columnNonce             = "nonce"
+
+	columnEventName       = "event_name"
+	columnContractID      = "contract_id"
+	columnContractAddress = "contract_address"
+	columnIdentityAddress = "identity_address"
+	columnAccountAddress  = "account_address"
+	columnBlockNumber     = "block_number"
+	columnTxIndex         = "tx_index"
+	columnBlockTimestamp  = "block_timestamp"
 )
 
 // pgTimeFormat is RFC3339 which has timezone information and accepted by pg

--- a/packages/demo/bridge/services/identity/db/main.go
+++ b/packages/demo/bridge/services/identity/db/main.go
@@ -31,6 +31,14 @@ type Database interface {
 	CreateLinkRequest(request LinkRequest) (int64, error)
 
 	SetStellarAccountCursor(id int64, cursor string) (int64, error)
+
+	// Gets the next link request for processing, sets the sender address for the
+	// link request to process.
+	// This operation locks the table to ensure that no link request can be
+	// process by multiple workers at the same time.
+	GetNextLinkRequest(senderAddress string) (*LinkRequest, error)
+
+	UpdateLinkRequest(request LinkRequest) (int64, error)
 }
 
 type PostgresDB struct {
@@ -67,8 +75,11 @@ type ReceivedPayment struct {
 type LinkRequest struct {
 	ID                int64       `db:"id"`
 	ReceivedPaymentID int64       `db:"received_payment_id"`
+	StellarAccount    string      `db:"from_account"`
 	EthereumAddress   string      `db:"ethereum_address"`
 	TxHash            null.String `db:"tx_hash"`
+	SenderAddress     null.String `db:"sender_address"`
+	Nonce             null.Int    `db:"nonce"`
 	Status            int64       `db:"status"`
 	Remarks           null.String `db:"remarks"`
 	Timestamp

--- a/packages/demo/bridge/services/identity/db/marshaller.go
+++ b/packages/demo/bridge/services/identity/db/marshaller.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"go.uber.org/zap/zapcore"
+)
+
+func (o StellarAccount) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt64("ID", o.ID)
+	enc.AddString("Address", o.Address)
+	if o.Cursor.Valid {
+		enc.AddString("Cursor", o.Cursor.String)
+	} else {
+		enc.AddReflected("Cursor", nil)
+	}
+	enc.AddInt64("Status", o.Status)
+	enc.AddTime("Last created", o.LastCreated)
+	enc.AddTime("Last modified", o.LastModified)
+	return nil
+}
+
+func (o ReceivedPayment) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt64("ID", o.ID)
+	enc.AddInt64("To account ID", o.ToAccountID)
+	enc.AddString("From account", o.FromAccount)
+	enc.AddInt64("Payment ID", o.PaymentID)
+	enc.AddString("TxHash", o.TxHash)
+	enc.AddString("Paging token", o.PagingToken)
+	enc.AddInt64("Status", o.Status)
+	enc.AddInt64("Memo type value", int64(o.MemoType))
+	if o.Memo.Valid {
+		enc.AddString("Memo", o.Memo.String)
+	}
+	enc.AddTime("Last created", o.LastCreated)
+	enc.AddTime("Last modified", o.LastModified)
+	return nil
+}
+
+func (o LinkRequest) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt64("ID", o.ID)
+	enc.AddInt64("Received payment id", o.ReceivedPaymentID)
+	enc.AddString("From stellar account", o.StellarAccount)
+	enc.AddString("Ethereum address", o.EthereumAddress)
+	if o.TxHash.Valid {
+		enc.AddString("TxHash", o.TxHash.String)
+	}
+	if o.SenderAddress.Valid {
+		enc.AddString("Sender address", o.SenderAddress.String)
+	}
+	if o.Nonce.Valid {
+		enc.AddInt64("Nonce", o.Nonce.Int64)
+	}
+	enc.AddInt64("Status", o.Status)
+	if o.Remarks.Valid {
+		enc.AddString("Remarks", o.Remarks.String)
+	}
+	enc.AddTime("Last created", o.LastCreated)
+	enc.AddTime("Last modified", o.LastModified)
+	return nil
+}
+
+func (o Contract) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt64("ID", o.ID)
+	enc.AddString("Address", o.Address)
+	enc.AddUint64("Block number", o.BlockNumber)
+	enc.AddTime("Last created", o.LastCreated)
+	enc.AddTime("Last modified", o.LastModified)
+	return nil
+}
+
+func (o StellarIdentityAccountsEvent) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddInt64("ID", o.ID)
+	enc.AddInt64("Contract ID", o.ContractID)
+	enc.AddString("Event name", o.EventName)
+	enc.AddString("Identity address", o.IdentityAddress)
+	enc.AddString("Stellar account address", o.AccountAddress)
+	enc.AddUint64("Block number", o.BlockNumber)
+	enc.AddUint("Transaction index", o.TxIndex)
+	enc.AddTime("Block timestamp", o.BlockTimestamp)
+	enc.AddTime("Last created", o.LastCreated)
+	enc.AddTime("Last modified", o.LastModified)
+	return nil
+}

--- a/packages/demo/bridge/services/identity/db/migrations/20181023154241_add_sender_address_and_nonce_columns.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181023154241_add_sender_address_and_nonce_columns.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS link_requests_sender_nonce;
+ALTER TABLE link_requests DROP COLUMN IF EXISTS sender_address;
+ALTER TABLE link_requests DROP COLUMN IF EXISTS nonce;

--- a/packages/demo/bridge/services/identity/db/migrations/20181023154241_add_sender_address_and_nonce_columns.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181023154241_add_sender_address_and_nonce_columns.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE link_requests ADD COLUMN sender_address varchar(64);
+ALTER TABLE link_requests ADD COLUMN nonce int;
+
+CREATE UNIQUE INDEX link_requests_sender_nonce ON link_requests (sender_address, nonce) WHERE sender_address IS NOT NULL AND nonce IS NOT NULL;

--- a/packages/demo/bridge/services/identity/db/migrations/20181026121026_create_contracts_sync_table.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181026121026_create_contracts_sync_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS contracts;

--- a/packages/demo/bridge/services/identity/db/migrations/20181026121026_create_contracts_sync_table.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181026121026_create_contracts_sync_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE contracts (
+  id                    serial                        PRIMARY KEY NOT NULL,
+  contract_address      varchar(64)                   NOT NULL,
+  block_number          int                           NOT NULL default 0,
+  last_created          timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+  last_modified         timestamp with time zone      NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TRIGGER contracts_modtime BEFORE UPDATE ON contracts FOR EACH ROW EXECUTE PROCEDURE update_last_modified_column();

--- a/packages/demo/bridge/services/identity/db/migrations/20181026121050_create_stellar_identity_accounts_event_table.down.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181026121050_create_stellar_identity_accounts_event_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS stellar_identity_accounts_events;

--- a/packages/demo/bridge/services/identity/db/migrations/20181026121050_create_stellar_identity_accounts_event_table.up.sql
+++ b/packages/demo/bridge/services/identity/db/migrations/20181026121050_create_stellar_identity_accounts_event_table.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE stellar_identity_accounts_events (
+  id                    serial                        PRIMARY KEY NOT NULL,
+  contract_id           int                           NOT NULL REFERENCES contracts(id),
+  event_name            text                          NOT NULL,
+  identity_address      varchar(64)                   NOT NULL,
+  account_address       varchar(64)                   NOT NULL,
+  tx_hash               varchar(64)                   NOT NULL UNIQUE,
+  block_number          int                           NOT NULL,
+  tx_index              int                           NOT NULL,
+  block_timestamp       timestamp with time zone      NOT NULL,
+  last_created          timestamp with time zone      NOT NULL DEFAULT current_timestamp,
+  last_modified         timestamp with time zone      NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TRIGGER stellar_identity_accounts_events_modtime BEFORE UPDATE ON stellar_identity_accounts_events FOR EACH ROW EXECUTE PROCEDURE update_last_modified_column();

--- a/packages/demo/bridge/services/identity/eventhandler/internal.go
+++ b/packages/demo/bridge/services/identity/eventhandler/internal.go
@@ -1,0 +1,12 @@
+package eventhandler
+
+import (
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/stellaridentityaccounts"
+)
+
+type stellarIdentityAccountsEvents interface {
+	ContractID() int64
+	StellarIdentityAccountsEvents() stellaridentityaccounts.AccountEventSlice
+	StartBlock() uint64
+	EndBlock() uint64
+}

--- a/packages/demo/bridge/services/identity/eventhandler/link_request_handler.go
+++ b/packages/demo/bridge/services/identity/eventhandler/link_request_handler.go
@@ -1,0 +1,208 @@
+package eventhandler
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"reflect"
+
+	"go.uber.org/zap"
+	"gopkg.in/guregu/null.v3"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"github.com/stellar/go/strkey"
+)
+
+func (h *LinkRequestHandler) Process(request db.LinkRequest) {
+	defer h.Mutex.Unlock() // Unblock for next link request
+
+	if !h.validateZeroAddress(request) {
+		return
+	}
+	if !h.validateIdentityAddress(request) {
+		return
+	}
+	if !h.validateNotLinked(request) {
+		return
+	}
+
+	nonce, err := h.EthereumClient.PendingNonceAt(context.Background(), h.FromAddress)
+	if err != nil {
+		h.Logger.Error("Unable to get pending nonce for address",
+			zap.Error(err),
+			zap.String("Address", h.FromAddress.Hex()),
+		)
+		return
+	}
+
+	gasPrice, err := h.EthereumClient.SuggestGasPrice(context.Background())
+	if err != nil {
+		h.Logger.Error("Unable to get suggested gas price",
+			zap.Error(err),
+		)
+		return
+	}
+
+	auth := bind.NewKeyedTransactor(h.PrivateKey)
+	auth.Nonce = big.NewInt(int64(nonce))
+	auth.Value = big.NewInt(0)     // in wei
+	auth.GasLimit = uint64(300000) // in units
+	auth.GasPrice = gasPrice
+
+	identity := common.HexToAddress(request.EthereumAddress)
+	account, _ := h.getStellarAccountBytes(request.StellarAccount)
+	tx, err := h.Contracts.StellarIdentityAccounts.AddAccount(auth, identity, account)
+	if err != nil {
+		h.Logger.Error("Unable to submit transaction",
+			zap.Error(err),
+			zap.String("Identity", identity.Hex()),
+			zap.ByteString("Account", account[:]),
+		)
+		return
+	}
+
+	request.Status = db.LinkRequestStatusQueued
+	request.TxHash = null.NewString(hex.EncodeToString(tx.Hash().Bytes()), true)
+	request.Nonce = null.NewInt(int64(nonce), true)
+
+	_, err = h.DB.UpdateLinkRequest(request)
+	if err != nil {
+		h.Logger.Error("Unable to update link request",
+			zap.Error(err),
+			zap.Int64("ID", request.ID),
+			zap.Int64("Status", request.Status),
+			zap.String("TxHash", request.TxHash.String),
+			zap.Int64("Nonce", request.Nonce.Int64),
+		)
+		return
+	}
+}
+
+func (h *LinkRequestHandler) validateZeroAddress(request db.LinkRequest) bool {
+	address := common.HexToAddress(request.EthereumAddress)
+	if !h.isZeroAddress(address) {
+		return true
+	}
+
+	request.Status = db.LinkRequestStatusValidationFailed
+	request.Remarks = null.NewString("Invalid address: Zero address", true)
+	h.Logger.Info("Unable to process link request: Zero address",
+		zap.Int64("Link request ID", request.ID),
+	)
+
+	_, err := h.DB.UpdateLinkRequest(request)
+	if err != nil {
+		h.Logger.Error("Unable to update link request",
+			zap.Error(err),
+			zap.Int64("ID", request.ID),
+			zap.Int64("Status", request.Status),
+			zap.String("Remarks", request.Remarks.String),
+		)
+		return false
+	}
+
+	return false
+}
+
+func (h *LinkRequestHandler) validateIdentityAddress(request db.LinkRequest) bool {
+	address := common.HexToAddress(request.EthereumAddress)
+
+	isIdentity, err := h.Contracts.IdentityRegistry.Identities(nil, address)
+	if err != nil {
+		h.Logger.Error("Unable to check contract for identity",
+			zap.Error(err),
+			zap.String("Identity to check", address.String()),
+		)
+		return false
+	}
+
+	if isIdentity {
+		return true
+	}
+
+	request.Status = db.LinkRequestStatusValidationFailed
+	request.Remarks = null.NewString("Invalid address: Non-identity address", true)
+	h.Logger.Info("Unable to process link request: Non-identity address",
+		zap.Int64("Link request ID", request.ID),
+		zap.String("Address", address.Hex()),
+	)
+	_, err = h.DB.UpdateLinkRequest(request)
+	if err != nil {
+		h.Logger.Error("Unable to update link request",
+			zap.Error(err),
+			zap.Int64("ID", request.ID),
+			zap.Int64("Status", request.Status),
+			zap.String("Remarks", request.Remarks.String),
+		)
+		return false
+	}
+
+	return false
+}
+
+func (h *LinkRequestHandler) validateNotLinked(request db.LinkRequest) bool {
+	account, ok := h.getStellarAccountBytes(request.StellarAccount)
+	if !ok {
+		return false
+	}
+
+	identityAddress, err := h.Contracts.StellarIdentityAccounts.GetIdentity(nil, account)
+	if err != nil {
+		h.Logger.Error("Unable to check contract for existing identity",
+			zap.Error(err),
+			zap.ByteString("Account to check", account[:]),
+		)
+		return false
+	}
+
+	if h.isZeroAddress(identityAddress) {
+		return true
+	}
+
+	request.Status = db.LinkRequestStatusValidationFailed
+	request.Remarks = null.NewString(fmt.Sprintf(
+		"Invalid request: Account linked to existing identity",
+	), true)
+	h.Logger.Info("Unable to process link request: Contains existing link",
+		zap.Int64("Link request ID", request.ID),
+		zap.String("Stellar account", request.StellarAccount),
+		zap.String("Identity contract", identityAddress.Hex()),
+	)
+
+	_, err = h.DB.UpdateLinkRequest(request)
+	if err != nil {
+		h.Logger.Error("Unable to update link request",
+			zap.Error(err),
+			zap.Int64("ID", request.ID),
+			zap.Int64("Status", request.Status),
+			zap.String("Remarks", request.Remarks.String),
+		)
+		return false
+	}
+
+	return false
+}
+
+func (h *LinkRequestHandler) isZeroAddress(address common.Address) bool {
+	zeroAddressBytes := common.FromHex("0x0000000000000000000000000000000000000000")
+	addressBytes := address.Bytes()
+	return reflect.DeepEqual(addressBytes, zeroAddressBytes)
+}
+
+func (h *LinkRequestHandler) getStellarAccountBytes(account string) ([32]byte, bool) {
+	stellarAccount, err := strkey.Decode(strkey.VersionByteAccountID, account)
+	if err != nil {
+		h.Logger.Error("Unable to decode stellar address to bytes",
+			zap.Error(err),
+			zap.String("Account", account),
+		)
+		return [32]byte{}, false
+	}
+	var res [32]byte
+	copy(res[32-len(stellarAccount):], stellarAccount)
+
+	return res, true
+}

--- a/packages/demo/bridge/services/identity/eventhandler/link_request_handler.go
+++ b/packages/demo/bridge/services/identity/eventhandler/link_request_handler.go
@@ -54,7 +54,7 @@ func (h *LinkRequestHandler) Process(request db.LinkRequest) {
 
 	identity := common.HexToAddress(request.EthereumAddress)
 	account, _ := h.getStellarAccountBytes(request.StellarAccount)
-	tx, err := h.Contracts.StellarIdentityAccounts.AddAccount(auth, identity, account)
+	tx, err := h.Contracts.StellarIdentityAccounts.Instance.AddAccount(auth, identity, account)
 	if err != nil {
 		h.Logger.Error("Unable to submit transaction",
 			zap.Error(err),
@@ -110,7 +110,7 @@ func (h *LinkRequestHandler) validateZeroAddress(request db.LinkRequest) bool {
 func (h *LinkRequestHandler) validateIdentityAddress(request db.LinkRequest) bool {
 	address := common.HexToAddress(request.EthereumAddress)
 
-	isIdentity, err := h.Contracts.IdentityRegistry.Identities(nil, address)
+	isIdentity, err := h.Contracts.IdentityRegistry.Instance.Identities(nil, address)
 	if err != nil {
 		h.Logger.Error("Unable to check contract for identity",
 			zap.Error(err),
@@ -149,7 +149,7 @@ func (h *LinkRequestHandler) validateNotLinked(request db.LinkRequest) bool {
 		return false
 	}
 
-	identityAddress, err := h.Contracts.StellarIdentityAccounts.GetIdentity(nil, account)
+	identityAddress, err := h.Contracts.StellarIdentityAccounts.Instance.GetIdentity(nil, account)
 	if err != nil {
 		h.Logger.Error("Unable to check contract for existing identity",
 			zap.Error(err),

--- a/packages/demo/bridge/services/identity/eventhandler/main.go
+++ b/packages/demo/bridge/services/identity/eventhandler/main.go
@@ -29,3 +29,9 @@ type LinkRequestHandler struct {
 	FromAddress    common.Address
 	Mutex          *sync.Mutex
 }
+
+type StellaridentityaccountsEventsHandler struct {
+	Logger     *zap.Logger
+	Fatalities chan error
+	DB         db.Database
+}

--- a/packages/demo/bridge/services/identity/eventhandler/main.go
+++ b/packages/demo/bridge/services/identity/eventhandler/main.go
@@ -1,6 +1,12 @@
 package eventhandler
 
 import (
+	"crypto/ecdsa"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
 	"github.com/stellar/go/clients/horizon"
 	"go.uber.org/zap"
@@ -11,5 +17,15 @@ type StellarPaymentHandler struct {
 	Fatalities    chan error
 	DB            db.Database
 	HorizonClient *horizon.Client
-	LinkRequests  chan db.LinkRequest
+}
+
+type LinkRequestHandler struct {
+	Logger         *zap.Logger
+	Fatalities     chan error
+	DB             db.Database
+	Contracts      *contract.Contracts
+	EthereumClient *ethclient.Client
+	PrivateKey     *ecdsa.PrivateKey
+	FromAddress    common.Address
+	Mutex          *sync.Mutex
 }

--- a/packages/demo/bridge/services/identity/eventhandler/stellar_payment_handler.go
+++ b/packages/demo/bridge/services/identity/eventhandler/stellar_payment_handler.go
@@ -86,6 +86,11 @@ func (h *StellarPaymentHandler) handleIncomingPayment(account *db.StellarAccount
 		EthereumAddress:   *ethAddress,
 		Status:            db.LinkRequestStatusPendingValidation,
 	}
+	h.Logger.Debug("Create link request",
+		zap.Any("Link Request", linkRequest),
+		zap.Any("Received payment", receivedPayment),
+	)
+
 	linkRequest.ID, err = h.DB.CreateLinkRequest(linkRequest)
 	if err != nil {
 		h.Logger.Error("Unable to create link request",
@@ -95,12 +100,6 @@ func (h *StellarPaymentHandler) handleIncomingPayment(account *db.StellarAccount
 		)
 		return
 	}
-
-	h.Logger.Debug("Enqueue link request",
-		zap.Any("Link Request", linkRequest),
-		zap.Any("Received payment", receivedPayment),
-	)
-	h.LinkRequests <- linkRequest
 }
 
 func (h *StellarPaymentHandler) parseMemo(payment *horizon.Payment) (ethAddress *string, memo null.String, memoType stellar.MemoType) {

--- a/packages/demo/bridge/services/identity/eventhandler/stellaridentityaccounts_events_handler.go
+++ b/packages/demo/bridge/services/identity/eventhandler/stellaridentityaccounts_events_handler.go
@@ -1,0 +1,56 @@
+package eventhandler
+
+import (
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"github.com/stellar/go/strkey"
+	"go.uber.org/zap"
+)
+
+func (h *StellaridentityaccountsEventsHandler) Receive(events stellarIdentityAccountsEvents) {
+	allEvents := events.StellarIdentityAccountsEvents()
+	dbEvents := make([]db.StellarIdentityAccountsEvent, 0)
+
+	// Sort by block number
+	sort.Slice(allEvents, func(i, j int) bool {
+		if allEvents[i].Raw.BlockNumber < allEvents[j].Raw.BlockNumber {
+			return true
+		} else if allEvents[i].Raw.BlockNumber > allEvents[j].Raw.BlockNumber {
+			return false
+		}
+
+		return strings.Compare(allEvents[i].Name, allEvents[j].Name) < 0
+	})
+
+	for _, ev := range allEvents {
+		identityAddress := hex.EncodeToString(ev.Identity.Bytes())
+		accountAddress, err := strkey.Encode(strkey.VersionByteAccountID, ev.Account[:])
+		if err != nil {
+			h.Logger.Error("Failed to parse stellar account address", zap.Error(err))
+			continue
+		}
+
+		dbEvents = append(dbEvents, db.StellarIdentityAccountsEvent{
+			ContractID:      events.ContractID(),
+			EventName:       ev.Name,
+			IdentityAddress: identityAddress,
+			AccountAddress:  accountAddress,
+			TxHash:          hex.EncodeToString(ev.Raw.TxHash.Bytes()),
+			BlockNumber:     ev.Raw.BlockNumber,
+			TxIndex:         ev.Raw.TxIndex,
+			BlockTimestamp:  time.Unix(ev.BlockHeader.Time.Int64(), 0),
+		})
+	}
+
+	err := h.DB.AddStellarIdentityAccountsEventsUntilBlockNumber(
+		events.ContractID(), events.EndBlock(), dbEvents)
+
+	if err != nil {
+		h.Logger.Error("Failed to save stellar identity accounts events", zap.Error(err))
+		return
+	}
+}

--- a/packages/demo/bridge/services/identity/listener/ethereum_events_listener.go
+++ b/packages/demo/bridge/services/identity/listener/ethereum_events_listener.go
@@ -1,0 +1,20 @@
+package listener
+
+import (
+	"sync"
+)
+
+func (e *EthereumEventsListener) StartListenStellarIdentityAccounts(events chan StellarIdentityAccountsEvents) {
+	e.Logger.Debug("Starting stream of StellarIdentityAccounts ethereum events")
+
+	listener := &stellaridentityaccountsListener{
+		Logger:    e.Logger,
+		DB:        e.DB,
+		Contracts: e.Contracts,
+		Client:    e.Client,
+		Events:    events,
+		Mutex:     &sync.Mutex{},
+	}
+
+	listener.Start()
+}

--- a/packages/demo/bridge/services/identity/listener/internal.go
+++ b/packages/demo/bridge/services/identity/listener/internal.go
@@ -1,0 +1,27 @@
+package listener
+
+import (
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
+	"go.uber.org/zap"
+)
+
+type stellaridentityaccountsListener struct {
+	Logger    *zap.Logger
+	DB        db.Database
+	Contracts *contract.Contracts
+	Client    *ethclient.Client
+	Events    chan StellarIdentityAccountsEvents
+	Mutex     *sync.Mutex
+}
+
+func waitFor(seconds int64, mutex *sync.Mutex) {
+	go func(seconds int64, mutex *sync.Mutex) {
+		time.Sleep(time.Duration(seconds) * time.Second)
+		mutex.Unlock()
+	}(seconds, mutex)
+}

--- a/packages/demo/bridge/services/identity/listener/main.go
+++ b/packages/demo/bridge/services/identity/listener/main.go
@@ -1,8 +1,11 @@
 package listener
 
 import (
+	"sync"
+
 	"go.uber.org/zap"
 
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
 	"github.com/stellar/go/clients/horizon"
 )
 
@@ -10,4 +13,12 @@ type StellarPayments struct {
 	Logger     *zap.Logger
 	Fatalities chan error
 	Client     *horizon.Client
+}
+
+type PendingLinkRequests struct {
+	Logger       *zap.Logger
+	Fatalities   chan error
+	DB           db.Database
+	LinkRequests chan db.LinkRequest
+	Mutex        *sync.Mutex
 }

--- a/packages/demo/bridge/services/identity/listener/main.go
+++ b/packages/demo/bridge/services/identity/listener/main.go
@@ -3,8 +3,13 @@ package listener
 import (
 	"sync"
 
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/stellaridentityaccounts"
+
 	"go.uber.org/zap"
 
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
 	"github.com/stellar/go/clients/horizon"
 )
@@ -21,4 +26,20 @@ type PendingLinkRequests struct {
 	DB           db.Database
 	LinkRequests chan db.LinkRequest
 	Mutex        *sync.Mutex
+}
+
+type EthereumEventsListener struct {
+	Logger     *zap.Logger
+	Fatalities chan error
+	DB         db.Database
+	Client     *ethclient.Client
+	Contracts  *contract.Contracts
+}
+
+type StellarIdentityAccountsEvents struct {
+	contractID   int64
+	blockHeaders map[uint64]*types.Header
+	events       stellaridentityaccounts.AccountEventSlice
+	startBlock   uint64
+	endBlock     uint64
 }

--- a/packages/demo/bridge/services/identity/listener/pending_link_requests.go
+++ b/packages/demo/bridge/services/identity/listener/pending_link_requests.go
@@ -1,0 +1,43 @@
+package listener
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func (r *PendingLinkRequests) Start(senderAddress string) {
+	for {
+		// Block until mutex is unlocked after pending link request is processed or
+		// after a timeout if there are no pending link requests.
+		r.Mutex.Lock()
+
+		linkRequest, err := r.DB.GetNextLinkRequest(senderAddress)
+		if err != nil {
+			r.Logger.Error("Unable to get next link request, retry after timeout",
+				zap.Error(err),
+				zap.Int64("Timeout", 5),
+			)
+			r.waitFor(5)
+			continue
+		}
+
+		if linkRequest == nil {
+			r.Logger.Info("No new link request, retry after timeout",
+				zap.Int64("Timeout", 5),
+			)
+			r.waitFor(5)
+			continue
+		}
+
+		r.LinkRequests <- *linkRequest
+	}
+}
+
+func (r *PendingLinkRequests) waitFor(seconds int64) {
+	go func(seconds int64, mutex *sync.Mutex) {
+		time.Sleep(time.Duration(seconds) * time.Second)
+		mutex.Unlock()
+	}(seconds, r.Mutex)
+}

--- a/packages/demo/bridge/services/identity/listener/stellaridentityaccounts_events.go
+++ b/packages/demo/bridge/services/identity/listener/stellaridentityaccounts_events.go
@@ -1,0 +1,21 @@
+package listener
+
+import (
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/stellaridentityaccounts"
+)
+
+func (e StellarIdentityAccountsEvents) ContractID() int64 {
+	return e.contractID
+}
+
+func (e StellarIdentityAccountsEvents) StellarIdentityAccountsEvents() stellaridentityaccounts.AccountEventSlice {
+	return e.events
+}
+
+func (e StellarIdentityAccountsEvents) StartBlock() uint64 {
+	return e.startBlock
+}
+
+func (e StellarIdentityAccountsEvents) EndBlock() uint64 {
+	return e.endBlock
+}

--- a/packages/demo/bridge/services/identity/listener/stellaridentityaccounts_listener.go
+++ b/packages/demo/bridge/services/identity/listener/stellaridentityaccounts_listener.go
@@ -1,0 +1,184 @@
+package listener
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract/stellaridentityaccounts"
+	"go.uber.org/zap"
+)
+
+func (l *stellaridentityaccountsListener) Start() {
+	for {
+		l.Mutex.Lock()
+		go l.getEvents()
+	}
+}
+
+func (l *stellaridentityaccountsListener) getEvents() {
+	header, err := l.Client.HeaderByNumber(context.Background(), nil)
+	if err != nil {
+		l.Logger.Error("Failed to get latest block, retry after timeout",
+			zap.Error(err),
+			zap.Int64("timeout", 5),
+		)
+		waitFor(5, l.Mutex)
+		return
+	}
+
+	latestContract, err := l.DB.LoadContract(l.Contracts.StellarIdentityAccounts.DB.Address)
+	if err != nil {
+		l.Logger.Error("Failed to get latest contract details from db, retry after timeout",
+			zap.Error(err),
+			zap.Int64("timeout", 5),
+		)
+		waitFor(5, l.Mutex)
+		return
+	}
+	l.Contracts.StellarIdentityAccounts.DB = *latestContract
+
+	endBlock := header.Number.Uint64()
+
+	if latestContract.BlockNumber == endBlock {
+		l.Logger.Info("No new blocks, retry after timeout",
+			zap.Int64("timeout", 15),
+		)
+		waitFor(15, l.Mutex)
+		return
+	}
+
+	filterOpts := bind.FilterOpts{
+		Start: latestContract.BlockNumber,
+		End:   &endBlock,
+	}
+
+	events := StellarIdentityAccountsEvents{
+		contractID: latestContract.ID,
+		events:     make([]stellaridentityaccounts.AccountEvent, 0),
+		startBlock: latestContract.BlockNumber,
+		endBlock:   endBlock,
+	}
+
+	err = l.getAccountRequested(&filterOpts, &events)
+	if err != nil {
+		l.Logger.Error("Failed to get AccountRequested events",
+			zap.Error(err),
+			zap.Uint64("StartBlock", filterOpts.Start),
+			zap.Any("EndBlock", filterOpts.End),
+		)
+		return
+	}
+	err = l.getAccountAdded(&filterOpts, &events)
+	if err != nil {
+		l.Logger.Error("Failed to get AccountAdded events",
+			zap.Error(err),
+			zap.Uint64("StartBlock", filterOpts.Start),
+			zap.Any("EndBlock", filterOpts.End),
+		)
+		return
+	}
+	err = l.getAccountRemoved(&filterOpts, &events)
+	if err != nil {
+		l.Logger.Error("Failed to get AccountRemoved events",
+			zap.Error(err),
+			zap.Uint64("StartBlock", filterOpts.Start),
+			zap.Any("EndBlock", filterOpts.End),
+		)
+		return
+	}
+
+	l.Events <- events
+	waitFor(15, l.Mutex)
+}
+
+func (l *stellaridentityaccountsListener) getAccountRequested(filterOpts *bind.FilterOpts, allEvents *StellarIdentityAccountsEvents) error {
+	events, err := l.Contracts.StellarIdentityAccounts.Instance.FilterAccountRequested(filterOpts)
+	if err != nil {
+		l.Logger.Error("Failed to get events", zap.Error(err))
+		return err
+	}
+
+	for events.Next() {
+		ev := events.Event
+		l.Logger.Debug("New stellar identity accounts AccountRequested event", zap.Any("event", ev))
+		accountEvent, err := l.makeStellarIdentityAccountsEvent(ev.Identity, ev.Account, ev.Raw)
+		if err != nil {
+			l.Logger.Error("Failed to get block by number",
+				zap.Error(err),
+				zap.Any("event", accountEvent),
+			)
+			continue
+		}
+		accountEvent.Name = "AccountRequested"
+		allEvents.events = append(allEvents.events, *accountEvent)
+	}
+
+	return nil
+}
+
+func (l *stellaridentityaccountsListener) getAccountAdded(filterOpts *bind.FilterOpts, allEvents *StellarIdentityAccountsEvents) error {
+	events, err := l.Contracts.StellarIdentityAccounts.Instance.FilterAccountAdded(filterOpts)
+	if err != nil {
+		l.Logger.Error("Failed to get events", zap.Error(err))
+		return err
+	}
+
+	for events.Next() {
+		ev := events.Event
+		l.Logger.Debug("New stellar identity accounts AccountAdded event", zap.Any("event", ev))
+		accountEvent, err := l.makeStellarIdentityAccountsEvent(ev.Identity, ev.Account, ev.Raw)
+		if err != nil {
+			l.Logger.Error("Failed to get block by number",
+				zap.Error(err),
+				zap.Any("event", accountEvent),
+			)
+			continue
+		}
+		accountEvent.Name = "AccountAdded"
+		allEvents.events = append(allEvents.events, *accountEvent)
+	}
+
+	return nil
+}
+
+func (l *stellaridentityaccountsListener) getAccountRemoved(filterOpts *bind.FilterOpts, allEvents *StellarIdentityAccountsEvents) error {
+	events, err := l.Contracts.StellarIdentityAccounts.Instance.FilterAccountRemoved(filterOpts)
+	if err != nil {
+		l.Logger.Error("Failed to get events", zap.Error(err))
+		return err
+	}
+
+	for events.Next() {
+		ev := events.Event
+		l.Logger.Debug("New stellar identity accounts AccountRemoved event", zap.Any("event", ev))
+		accountEvent, err := l.makeStellarIdentityAccountsEvent(ev.Identity, ev.Account, ev.Raw)
+		if err != nil {
+			l.Logger.Error("Failed to get block by number",
+				zap.Error(err),
+				zap.Any("event", accountEvent),
+			)
+			continue
+		}
+		accountEvent.Name = "AccountRemoved"
+		allEvents.events = append(allEvents.events, *accountEvent)
+	}
+
+	return nil
+}
+
+func (l *stellaridentityaccountsListener) makeStellarIdentityAccountsEvent(identity common.Address, account [32]byte, log types.Log) (*stellaridentityaccounts.AccountEvent, error) {
+	header, err := l.Client.HeaderByNumber(context.Background(), big.NewInt(int64(log.BlockNumber)))
+	if err != nil {
+		return nil, err
+	}
+
+	return &stellaridentityaccounts.AccountEvent{
+		Identity:    identity,
+		Account:     account,
+		Raw:         log,
+		BlockHeader: header,
+	}, nil
+}

--- a/packages/demo/bridge/services/identity/main.go
+++ b/packages/demo/bridge/services/identity/main.go
@@ -1,16 +1,25 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/config"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/config/key"
+	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/contract"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/db"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/eventhandler"
 	"github.com/rate-engineering/rate3-monorepo/packages/demo/bridge/services/identity/listener"
@@ -24,7 +33,7 @@ func initLogger() *zap.Logger {
 		return lvl >= zapcore.ErrorLevel
 	})
 	lowPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
-		return lvl < zapcore.ErrorLevel && lvl > zapcore.DebugLevel
+		return lvl < zapcore.ErrorLevel // && lvl > zapcore.DebugLevel
 	})
 
 	// High-priority output should go to standard error,
@@ -50,24 +59,67 @@ func initLogger() *zap.Logger {
 	return logger.Named("Bridge")
 }
 
-func main() {
-	logger := initLogger()
-	defer logger.Sync()
-
+func initConfig(logger *zap.Logger) *config.Config {
 	_config, err := config.Init()
 	if err != nil {
 		logger.Fatal("Unable to initialize configuration", zap.Error(err))
 	}
+	return _config
+}
 
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt, os.Kill, syscall.SIGTERM)
-
-	dbClient, err := db.NewPostgresDB(_config.Database, logger.Named("DB"))
+func initDB(logger *zap.Logger, cfg *config.Config) db.Database {
+	dbClient, err := db.NewPostgresDB(cfg.Database, logger.Named("DB"))
 	if err != nil {
 		logger.Fatal("Unable to initialize db client", zap.Error(err))
 	}
+	return dbClient
+}
 
-	stellarKeypair, err := key.StellarKeypairFromSecret(_config.Keys.Stellar.DecryptedSecret)
+func initEthereumClient(logger *zap.Logger, cfg *config.Config) *ethclient.Client {
+	ethereumClient, err := ethclient.Dial(cfg.Networks.Ethereum.URL)
+	if err != nil {
+		logger.Fatal("Unable to connect to ethereum provider",
+			zap.Error(err),
+			zap.String("Provider URL", cfg.Networks.Ethereum.URL),
+		)
+	}
+
+	return ethereumClient
+}
+
+func initHorizonClient(logger *zap.Logger, cfg *config.Config) *horizon.Client {
+	return &horizon.Client{
+		URL:  cfg.Networks.Stellar.URL,
+		HTTP: http.DefaultClient,
+	}
+}
+
+func initContracts(logger *zap.Logger, cfg *config.Config, ethereumClient *ethclient.Client) *contract.Contracts {
+	contracts, err := contract.NewContracts(
+		logger,
+		ethereumClient,
+		cfg.Networks.Ethereum.IdentityRegistryAddr,
+		cfg.Networks.Ethereum.StellarIdentityAccountsAddr,
+	)
+	if err != nil {
+		logger.Fatal("Failed to initialize contracts", zap.Error(err))
+	}
+	return contracts
+}
+
+func initPrivateKey(logger *zap.Logger, cfg *config.Config) *ecdsa.PrivateKey {
+	privateKey, err := crypto.HexToECDSA(string(cfg.Keys.Ethereum.DecryptedPrivateKey))
+	if err != nil {
+		logger.Fatal("Unable to convert private key to ECDSA",
+			zap.Error(err),
+		)
+	}
+
+	return privateKey
+}
+
+func loadStellarAccount(logger *zap.Logger, cfg *config.Config, dbClient db.Database) *db.StellarAccount {
+	stellarKeypair, err := key.StellarKeypairFromSecret(cfg.Keys.Stellar.DecryptedSecret)
 	if err != nil {
 		logger.Fatal("Unable to decode stellar keypair", zap.Error(err))
 	}
@@ -77,14 +129,59 @@ func main() {
 		logger.Fatal("Unable to load stellar account", zap.Error(err))
 	}
 
+	return stellarAccount
+}
+
+func validateContractOwner(logger *zap.Logger, cfg *config.Config, privateKey *ecdsa.PrivateKey, contracts *contract.Contracts) common.Address {
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		logger.Fatal("Unable to get public address from private key")
+	}
+
+	ethereumAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
+
+	logger.Info("Checking owner of stellar identity contract",
+		zap.String("Address", contracts.StellarIdentityAccountsAddress.String()),
+	)
+
+	ownerAddress, err := contracts.StellarIdentityAccounts.Owner(nil)
+	if err != nil {
+		logger.Fatal("Unable to call smart contract",
+			zap.Error(err),
+		)
+	} else if ownerAddress != ethereumAddress {
+		logger.Fatal("Configured account is not owner of stellar identity contract",
+			zap.String("Stellar identity contract owner", ownerAddress.String()),
+			zap.String("Configured account", ethereumAddress.String()),
+		)
+	}
+
+	return ownerAddress
+}
+
+func main() {
+	logger := initLogger()
+	defer logger.Sync()
+
+	cfg := initConfig(logger)
+	dbClient := initDB(logger, cfg)
+	stellarAccount := loadStellarAccount(logger, cfg, dbClient)
+
 	fatalities := make(chan error)
 	ethereumLinkRequests := make(chan db.LinkRequest)
 	stellarIncomingPayments := make(chan horizon.Payment)
+	interrupt := make(chan os.Signal, 1)
+	ethereumTransactionMutex := &sync.Mutex{}
 
-	horizonClient := &horizon.Client{
-		URL:  _config.Networks.Stellar.URL,
-		HTTP: http.DefaultClient,
-	}
+	signal.Notify(interrupt, os.Interrupt, os.Kill, syscall.SIGTERM)
+
+	ethereumClient := initEthereumClient(logger, cfg)
+	horizonClient := initHorizonClient(logger, cfg)
+
+	privateKey := initPrivateKey(logger, cfg)
+	contracts := initContracts(logger, cfg, ethereumClient)
+	ownerAddress := validateContractOwner(logger, cfg, privateKey, contracts)
 
 	stellarPaymentsListener := &listener.StellarPayments{
 		Logger:     logger.Named("StellarPaymentsListener"),
@@ -94,12 +191,32 @@ func main() {
 
 	go stellarPaymentsListener.Start(stellarAccount.Address, stellarAccount.Cursor, stellarIncomingPayments)
 
+	pendingLinkRequestListener := &listener.PendingLinkRequests{
+		Logger:       logger.Named("PendingLinkRequests"),
+		Fatalities:   fatalities,
+		DB:           dbClient,
+		LinkRequests: ethereumLinkRequests,
+		Mutex:        ethereumTransactionMutex,
+	}
+
+	go pendingLinkRequestListener.Start(hex.EncodeToString(ownerAddress.Bytes()))
+
 	stellarPaymentHandler := &eventhandler.StellarPaymentHandler{
 		Logger:        logger.Named("StellarPaymentsHandler"),
 		DB:            dbClient,
 		Fatalities:    fatalities,
 		HorizonClient: horizonClient,
-		LinkRequests:  ethereumLinkRequests,
+	}
+
+	linkRequestHandler := &eventhandler.LinkRequestHandler{
+		Logger:         logger.Named("LinkRequestHandler"),
+		DB:             dbClient,
+		Fatalities:     fatalities,
+		Contracts:      contracts,
+		EthereumClient: ethereumClient,
+		PrivateKey:     privateKey,
+		FromAddress:    ownerAddress,
+		Mutex:          ethereumTransactionMutex,
 	}
 
 	for {
@@ -112,10 +229,28 @@ func main() {
 			go stellarPaymentHandler.Receive(stellarAccount, &payment)
 		case linkRequest := <-ethereumLinkRequests:
 			logger.Info("Link request received", zap.Any("Request", linkRequest))
+			linkRequestHandler.Process(linkRequest)
 		case killSignal := <-interrupt:
 			logger.Debug("Got signal", zap.Any("signal", killSignal))
 			logger.Debug("Killing service")
 			return
 		}
 	}
+}
+
+func publicAddress(privateKeyBytes []byte) (*common.Address, error) {
+	privateKey, err := crypto.HexToECDSA(string(privateKeyBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey := privateKey.Public()
+	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("Error casting public key to ECDSA")
+	}
+
+	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
+
+	return &fromAddress, nil
 }

--- a/packages/ethereum-contracts/contracts/identity/IdentityRegistry.sol
+++ b/packages/ethereum-contracts/contracts/identity/IdentityRegistry.sol
@@ -25,8 +25,8 @@ contract IdentityRegistry is Ownable {
         keyEnums = _keyEnums;
     }
 
-    // Mapping from ethereum wallet to ERC725 + ERC735 identity
-    mapping (address => address) public identities;
+    // All identity contracts
+    mapping (address => bool) public identities;
 
     // Mapping of networks to identity accounts, i.e. Ethereum = 1, Stellar = 2
     mapping (uint256 => IdentityAccounts) public networkAccounts;
@@ -42,27 +42,15 @@ contract IdentityRegistry is Ownable {
             ethIdentityAccounts != address(0),
             "Ethereum identity accounts is not set"
         );
-        require(identities[msg.sender] == address(0), "Identity exists");
         Identity newIdentity = new Identity(msg.sender, keyEnums);
-        identities[msg.sender] = newIdentity;
+        require(identities[newIdentity] == false, "Identity exists");
+        identities[newIdentity] = true;
 
         ethIdentityAccounts.newIdentity(newIdentity, msg.sender);
 
         emit NewIdentity(msg.sender, newIdentity);
 
         return newIdentity;
-    }
-
-    /**
-     * @dev Checks whether an identity exists in the registry
-     * @param addr The identity contract address to check for
-     */
-    function hasIdentity(address addr)
-        public
-        view
-        returns (bool)
-    {
-        return identities[addr] != address(0);
     }
 
     function setEthereumIdentityAccounts(EthereumIdentityAccounts acc)

--- a/packages/ethereum-contracts/test/identity/identityRegistry.js
+++ b/packages/ethereum-contracts/test/identity/identityRegistry.js
@@ -86,7 +86,7 @@ contract('IdentityRegistry Test', async (addrs) => {
             });
 
             it('should have registered identity', async () => {
-                assert.isTrue(await registry.hasIdentity(addrs[0]));
+                assert.isTrue(await registry.identities(identity.address));
             });
 
             it('should have keys', async () => {


### PR DESCRIPTION
# New packages
- Add `services/identity/contract` package for auto generated contracts.

# Features
- Creates the pending link request, saves it in db.
- Calls the stellar identity accounts contract to add the stellar address from the queue of pending link requests.
- Stores the transaction details of the contract call.