### PR TITLE
add GA tracking to token swap demo

### DIFF
--- a/packages/demo/token-swap/package-lock.json
+++ b/packages/demo/token-swap/package-lock.json
@@ -13462,6 +13462,11 @@
         }
       }
     },
+    "react-ga": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.5.7.tgz",
+      "integrity": "sha512-UmATFaZpEQDO96KFjB5FRLcT6hFcwaxOmAJZnjrSiFN/msTqylq9G+z5Z8TYzN/dbamDTiWf92m6MnXXJkAivQ=="
+    },
     "react-is": {
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.3.tgz",

--- a/packages/demo/token-swap/package.json
+++ b/packages/demo/token-swap/package.json
@@ -15,6 +15,7 @@
     "moment": "^2.23.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
+    "react-ga": "^2.5.7",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/packages/demo/token-swap/src/components/WithTracker.tsx
+++ b/packages/demo/token-swap/src/components/WithTracker.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import ReactGa from 'react-ga';
+import { TRACKING_ID } from '../constants/defaults';
+
+
+ReactGa.initialize(TRACKING_ID);
+
+const withTracker = (WrappedComponent) => {
+  const trackPage = (page) => {
+    ReactGa.set({ page });
+    ReactGa.pageview(page);
+    console.log('tracking');
+  };
+
+  const HOC = class extends React.Component {
+    componentDidMount() {
+      const props = this.props as any;
+      console.log(this.props);
+      const page = props.location.pathname;
+      trackPage(page);
+    }
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  };
+
+  return HOC as any;
+};
+export default withTracker;

--- a/packages/demo/token-swap/src/constants/defaults.ts
+++ b/packages/demo/token-swap/src/constants/defaults.ts
@@ -66,3 +66,5 @@ export const ETHERSCAN = 'https://ropsten.etherscan.io';
 
 // export const INFURA = 'https://ropsten.infura.io';
 export const INFURA = 'https://ropsten.infura.io/v3/81cc2101ca344ef8a8fe5742a70249f0';
+
+export const TRACKING_ID = 'UA-114112342-6';

--- a/packages/demo/token-swap/src/pages/DirectSwapPage.tsx
+++ b/packages/demo/token-swap/src/pages/DirectSwapPage.tsx
@@ -1,26 +1,30 @@
-import Input from '@material-ui/core/Input';
-import { createStyles } from '@material-ui/core/styles';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import classnames from 'classnames';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { RouteComponentProps } from 'react-router-dom';
 import { Dispatch } from 'redux';
+
+import Input from '@material-ui/core/Input';
+import { createStyles } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
 import * as networkActions from '../actions/network';
 import * as actions from '../actions/user';
+import exchangeSvg from '../assets/exchange.svg';
 import BlueButton from '../components/common/BlueButton';
 import SummaryCard from '../components/common/SummaryCard';
 import PageBox from '../components/layout/PageBox';
 import PageContainer from '../components/layout/PageContainer';
 import PageTitle from '../components/layout/PageTitle';
+import withTracker from '../components/WithTracker';
 import { SIDEBAR } from '../constants/colors';
 import { IE2SRequest, IS2ERequest } from '../reducers/issuer';
 import { initialState, IStoreState } from '../reducers/network';
 import { Direction, IAction } from '../utils/general';
 import SwapDetailsPage from './SwapDetailsPage';
 import SwapRequestPage from './SwapRequestPage';
-import exchangeSvg from '../assets/exchange.svg';
+
 const styles = createStyles({
   toggleBtn: {
     position: 'relative',
@@ -303,4 +307,4 @@ export function mapDispatchToProps(dispatch: Dispatch<IAction>) {
   };
 }
 export default connect(
-  mapStateToProps, mapDispatchToProps)(withStyles(styles)(withRouter(DirectSwapPage)));
+  mapStateToProps, mapDispatchToProps)(withStyles(styles)(withRouter(withTracker(DirectSwapPage))));

--- a/packages/demo/token-swap/src/pages/IssuerHomePage.tsx
+++ b/packages/demo/token-swap/src/pages/IssuerHomePage.tsx
@@ -1,23 +1,26 @@
-import { createStyles } from '@material-ui/core/styles';
-import RoleContext from '../components/common/RoleContext';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { RouteComponentProps } from 'react-router-dom';
 import { Dispatch } from 'redux';
+
+import { createStyles } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
 import * as networkActions from '../actions/network';
+import RoleContext from '../components/common/RoleContext';
 import AwaitingApprovalList from '../components/issuer/AwaitingApprovalList';
 import HistoryList from '../components/issuer/HistoryList';
 import Box from '../components/layout/Box';
 import PageBox from '../components/layout/PageBox';
 import PageContainer from '../components/layout/PageContainer';
 import PageTitle from '../components/layout/PageTitle';
+import withTracker from '../components/WithTracker';
 import { COLORS } from '../constants/colors';
 import { ROLES } from '../constants/general';
 import { IE2SRequest, IS2ERequest } from '../reducers/issuer';
 import { initialState, IStoreState } from '../reducers/network';
-import { Direction, IAction, calStellarTodaySwapNo, calEthTodaySwapNo } from '../utils/general';
+import { calEthTodaySwapNo, calStellarTodaySwapNo, Direction, IAction } from '../utils/general';
 import HistorySwapDetailsPage from './HistorySwapDetailsPage';
 import SwapApprovalPage from './SwapApprovalPage';
 import SwapDetailsPage from './SwapDetailsPage';
@@ -275,4 +278,4 @@ export function mapDispatchToProps(dispatch: Dispatch<IAction>) {
   };
 }
 export default connect(
-  mapStateToProps, mapDispatchToProps)(withStyles(styles)(withRouter(IssuerHomePage)));
+  mapStateToProps, mapDispatchToProps)(withStyles(styles)(withRouter(withTracker(IssuerHomePage))));

--- a/packages/demo/token-swap/src/pages/MobileFallback.js
+++ b/packages/demo/token-swap/src/pages/MobileFallback.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { COLORS } from '../constants/colors';
 import Rate3Logo from '../assets/rate3Logo.svg';
+import ReactGa from 'react-ga';
 import coin from '../assets/coin_fly.svg';
+import withTracker from '../components/WithTracker';
+import { withRouter } from 'react-router-dom';
+import { TRACKING_ID } from '../constants/defaults';
 const Container = (props) => {
   return (
     <div style={{ width: '75%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
@@ -9,34 +13,39 @@ const Container = (props) => {
     </div>
   );
 }
-const MobileFallback = () => {
-  const backgroundStyle = {
-    backgroundColor: COLORS.blue,
-    height: '100vh',
-    width: '100vw',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'space-around',
-  };
-  return (
-    <div style={backgroundStyle}>
-      <Container>
-        <div style={{ paddingTop: '10vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
-          <img src={Rate3Logo} style={{ height: '5vh' }} alt="rate3 logo" />
-          <p style={{ textAlign: 'center', fontWeight: 200, fontSize: '5vh', color: 'white' }}>Cross Chain Demo</p>
-        </div>
-      </Container>
-      <Container><img style={{ height: '22vh' }} src={coin} alt="rate3 logo" /></Container>
-      <Container>
-        <div style={{ paddingBottom: '10vh' }}>
-          <p style={{ textAlign: 'center', fontSize: '3.8vh', color: 'white' }}>Only on Desktop Browsers</p>
-          <p style={{ textAlign: 'center', fontSize: '3vh', color: 'white' }}>Bookmark and try it on Desktop</p>
-        </div>
-
-      </Container>
-    </div>
-  );
+class MobileFallback extends React.Component {
+  componentDidMount() {
+    ReactGa.initialize(TRACKING_ID);
+    ReactGa.pageview('/mobile_fallback');
+  }
+  render () {
+    const backgroundStyle = {
+      backgroundColor: COLORS.blue,
+      height: '100vh',
+      width: '100vw',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'space-around',
+    };
+    return (
+      <div style={backgroundStyle}>
+        <Container>
+          <div style={{ paddingTop: '10vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
+            <img src={Rate3Logo} style={{ height: '5vh' }} alt="rate3 logo" />
+            <p style={{ textAlign: 'center', fontWeight: 200, fontSize: '5vh', color: 'white' }}>Cross Chain Demo</p>
+          </div>
+        </Container>
+        <Container><img style={{ height: '22vh' }} src={coin} alt="rate3 logo" /></Container>
+        <Container>
+          <div style={{ paddingBottom: '10vh' }}>
+            <p style={{ textAlign: 'center', fontSize: '3.8vh', color: 'white' }}>Only on Desktop Browsers</p>
+            <p style={{ textAlign: 'center', fontSize: '3vh', color: 'white' }}>Bookmark and try it on Desktop</p>
+          </div>
+        </Container>
+      </div>
+    );
+  }
 };
 
 export default MobileFallback;

--- a/packages/demo/token-swap/src/pages/OnboardingPage.tsx
+++ b/packages/demo/token-swap/src/pages/OnboardingPage.tsx
@@ -1,19 +1,23 @@
-import { AppBar, Toolbar } from '@material-ui/core';
-import { createStyles } from '@material-ui/core/styles';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import * as React from 'react';
 import { withRouter } from 'react-router';
 import { Link, RouteComponentProps } from 'react-router-dom';
-import BlueButton from '../components/common/BlueButton';
-import { ONBOARDING, SIDEBAR } from '../constants/colors';
-import userLogo from '../assets/user_rate3_logo.svg';
-import { ONBOARDING_TEXTS } from '../constants/defaults';
+
+import { AppBar, Toolbar } from '@material-ui/core';
+import { createStyles } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
 import coin from '../assets/coin_fly.svg';
-import page2 from '../assets/page2.svg';
-import p2p1 from '../assets/p2p.svg';
-import p2p2 from '../assets/p2p_2.svg';
 import direct1 from '../assets/direct_1.svg';
 import direct2 from '../assets/direct_2.svg';
+import p2p1 from '../assets/p2p.svg';
+import p2p2 from '../assets/p2p_2.svg';
+import page2 from '../assets/page2.svg';
+import userLogo from '../assets/user_rate3_logo.svg';
+import BlueButton from '../components/common/BlueButton';
+import { ONBOARDING, SIDEBAR } from '../constants/colors';
+import { ONBOARDING_TEXTS } from '../constants/defaults';
+import withTracker from '../components/WithTracker';
+
 // export interface IProps {
 //   classes: any;
 // }
@@ -229,4 +233,4 @@ class OnboardingPage extends React.PureComponent<IProps> {
   }
 }
 
-export default withStyles(styles)(withRouter(OnboardingPage));
+export default withStyles(styles)(withRouter(withTracker(OnboardingPage)));

--- a/packages/demo/token-swap/src/pages/SwapApprovalPage.tsx
+++ b/packages/demo/token-swap/src/pages/SwapApprovalPage.tsx
@@ -1,23 +1,26 @@
-import { createStyles } from '@material-ui/core/styles';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import day from 'dayjs';
 import * as React from 'react';
+import ReactGa from 'react-ga';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { Dispatch } from 'redux';
+
+import { createStyles } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
 import * as actions from '../actions/issuer';
 import lineSvg from '../assets/line.svg';
 import BlueButton from '../components/common/BlueButton';
+import Pop from '../components/common/Pop';
 import SwapInfoBox from '../components/common/SwapInfoBox';
 import Box from '../components/layout/Box';
 import PageBox from '../components/layout/PageBox';
 import PageContainer from '../components/layout/PageContainer';
 import PageTitle from '../components/layout/PageTitle';
 import { COLORS } from '../constants/colors';
-import { CONVERSION_CONTRACT_ADDR, ETH_USER, STELLAR_USER } from '../constants/defaults';
+import { CONVERSION_CONTRACT_ADDR, ETH_USER, STELLAR_USER, TRACKING_ID } from '../constants/defaults';
 import { IE2SRequest, IS2ERequest } from '../reducers/issuer';
 import { Direction, IAction, truncateAddress } from '../utils/general';
-import day from 'dayjs';
-import Pop from '../components/common/Pop';
 
 const FORMAT = 'DD-MM-YYYY H:mm';
 const styles = createStyles({
@@ -91,6 +94,8 @@ class SwapApprovalPage extends React.Component<IPropsFinal> {
     };
   }
   componentDidMount() {
+    ReactGa.initialize(TRACKING_ID);
+    ReactGa.pageview('/issuer/approve');
   }
 
   render() {

--- a/packages/demo/token-swap/src/pages/UserHomePage.tsx
+++ b/packages/demo/token-swap/src/pages/UserHomePage.tsx
@@ -1,10 +1,12 @@
-import { createStyles } from '@material-ui/core/styles';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { RouteComponentProps } from 'react-router-dom';
 import { Dispatch } from 'redux';
+
+import { createStyles } from '@material-ui/core/styles';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+
 import * as actions from '../actions/network';
 import RoleContext from '../components/common/RoleContext';
 import HistoryList from '../components/issuer/HistoryList';
@@ -12,11 +14,12 @@ import Box from '../components/layout/Box';
 import PageBox from '../components/layout/PageBox';
 import PageContainer from '../components/layout/PageContainer';
 import PageTitle from '../components/layout/PageTitle';
+import withTracker from '../components/WithTracker';
 import { COLORS } from '../constants/colors';
 import { ROLES } from '../constants/general';
-import { IAction, calStellarTodaySwapNo, calEthTodaySwapNo } from '../utils/general';
-import HistorySwapDetailsPage from './HistorySwapDetailsPage';
 import { initialState, IStoreState } from '../reducers/network';
+import { calEthTodaySwapNo, calStellarTodaySwapNo, IAction } from '../utils/general';
+import HistorySwapDetailsPage from './HistorySwapDetailsPage';
 
 const styles = createStyles({
   row: {
@@ -211,6 +214,6 @@ export function mapDispatchToProps(dispatch: Dispatch<IAction>) {
   };
 }
 export default connect(
-  mapStateToProps, mapDispatchToProps)(withRouter(withStyles(styles)(UserHomePage)));
+  mapStateToProps, mapDispatchToProps)(withRouter(withTracker(withStyles(styles)(UserHomePage))));
 
 // export default withRouter(withStyles(styles)(UserHomePage));


### PR DESCRIPTION
add GA tracking for pageviews

since `approve` page and mobile fallback do not have distinctive url, instead of passing the pathname directly I sent `/issuer/approve` and `/mobile_fallback` manually to GA.